### PR TITLE
Add Playwright E2E tests and CI workflow for web app

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,0 +1,52 @@
+name: Web E2E
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/web-e2e.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/web-e2e.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Playwright (Chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        env:
+          CI: true
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          if-no-files-found: ignore
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -11,3 +11,5 @@ dist-ssr
 .vinxi
 __unconfig*
 todos.json
+playwright-report
+test-results

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,6 +25,13 @@ This project uses [Vitest](https://vitest.dev/) for testing. You can run the tes
 npm run test
 ```
 
+This project also includes [Playwright](https://playwright.dev/) E2E tests in `e2e/`:
+
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
+
 ## Styling
 
 This project uses [Tailwind CSS](https://tailwindcss.com/) for styling.

--- a/apps/web/e2e/api.spec.ts
+++ b/apps/web/e2e/api.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+test('GET /api serves the API reference document', async ({ request }) => {
+  const response = await request.get('/api')
+
+  expect(response.status()).toBe(200)
+  expect(response.headers()['content-type']).toContain('text/html')
+
+  const body = await response.text()
+  expect(body).toContain('<title>API Reference</title>')
+  expect(body).toContain('TanStack ORPC Playground')
+})
+
+test('POST /api/rpc/listTodos rejects malformed payloads', async ({ request }) => {
+  const response = await request.post('/api/rpc/listTodos')
+
+  expect(response.status()).toBe(400)
+
+  const body = await response.json()
+  expect(body).toMatchObject({
+    json: {
+      code: 'BAD_REQUEST',
+      status: 400,
+      message: 'Input validation failed',
+    },
+  })
+})

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test'
+
+test('home route renders the starter content', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page).toHaveTitle('Hello World')
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Build from a stronger baseline.' }),
+  ).toBeVisible()
+  await expect(page.getByText('Starter App')).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Learn more about this starter' })).toBeVisible()
+})
+
+test('users can navigate between home and about routes', async ({ page }) => {
+  await page.goto('/')
+
+  await page.getByRole('link', { name: 'Learn more about this starter' }).click()
+  await expect(page).toHaveURL(/\/about$/)
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: 'What this project gives you out of the box.',
+    }),
+  ).toBeVisible()
+
+  await page.getByRole('link', { name: 'Back to home' }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Build from a stronger baseline.' }),
+  ).toBeVisible()
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
     "format": "biome format",
     "lint": "biome lint",
     "check": "biome check",
@@ -76,6 +78,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.5",
     "@inlang/paraglide-js": "^2.13.1",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/devtools-event-client": "latest",
     "@tanstack/devtools-vite": "latest",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const port = Number(process.env.PLAYWRIGHT_WEB_PORT ?? 4173)
+const baseURL = `http://localhost:${port}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --port ${port}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+})


### PR DESCRIPTION
## Summary
- add Playwright setup for `apps/web` with a dedicated local test server port
- add E2E specs for core route navigation between home and about
- add API endpoint coverage for `/api` docs and malformed RPC payload handling
- add a GitHub Actions workflow to run `apps/web` Playwright E2E tests on PRs and pushes to `main`

## CI Workflow
- workflow: `.github/workflows/web-e2e.yml`
- Node 22 on `ubuntu-latest`
- installs dependencies in `apps/web`
- installs Playwright Chromium with system deps
- runs `npm run test:e2e`
- uploads Playwright artifacts on failure

## Testing
- `npm run test:e2e`
