### PR TITLE
[codex] add web build workflow

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,50 @@
+name: Web Build
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/web-build.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/web/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/web-build.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/app_starter
+      BETTER_AUTH_URL: http://127.0.0.1:3000
+      BETTER_AUTH_SECRET: ci-build-secret-ci-build-secret
+      SERVER_URL: http://127.0.0.1:3000
+      VITE_APP_TITLE: app-starter
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web app
+        run: pnpm --filter web build


### PR DESCRIPTION
## Summary
- add a dedicated `Web Build` GitHub Actions workflow for the TanStack Start app
- run `pnpm install --frozen-lockfile` and `pnpm --filter web build` with the repo's pinned pnpm and Node versions
- provide CI-safe placeholder env vars so the server-auth and DB imports required during build do not fail on missing configuration

## Why
The repo already had E2E coverage, but it did not have a fast, focused build check to catch production build regressions in pull requests. This adds that signal without coupling it to Playwright.

## Impact
PRs that touch the web app, lockfile, or root package manifest will now verify that the production app build still succeeds on GitHub Actions.

## Validation
- `pnpm install --frozen-lockfile`
- `CI=true DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/app_starter BETTER_AUTH_URL=http://127.0.0.1:3000 BETTER_AUTH_SECRET=ci-build-secret-ci-build-secret SERVER_URL=http://127.0.0.1:3000 VITE_APP_TITLE=app-starter pnpm --filter web build`