### PR TITLE
[codex] Add full-stack web CI coverage

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,21 +1,25 @@
-name: Web E2E
+name: Web CI
 
 on:
   pull_request:
     paths:
       - "apps/web/**"
-      - "pnpm-lock.yaml"
       - ".github/workflows/web-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   push:
     branches:
       - main
     paths:
       - "apps/web/**"
-      - "pnpm-lock.yaml"
       - ".github/workflows/web-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 jobs:
-  e2e:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -36,14 +40,81 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        working-directory: .
+
+      - name: Check formatting and lint rules
+        run: pnpm --filter web check
+
+      - name: Run unit tests
+        run: pnpm --filter web test
+
+      - name: Build app
+        env:
+          BETTER_AUTH_SECRET: playwright-test-secret-with-adequate-length
+          BETTER_AUTH_URL: http://127.0.0.1:4173
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/app_starter
+          SERVER_URL: http://127.0.0.1:4173
+          VITE_APP_TITLE: app-starter
+        run: pnpm --filter web build
+
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      BETTER_AUTH_SECRET: playwright-test-secret-with-adequate-length
+      BETTER_AUTH_URL: http://127.0.0.1:4173
+      CI: true
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/app_starter
+      PLAYWRIGHT_SERVER_MODE: build
+      PLAYWRIGHT_WEB_HOST: 127.0.0.1
+      PLAYWRIGHT_WEB_PORT: "4173"
+      SERVER_URL: http://127.0.0.1:4173
+      VITE_APP_TITLE: app-starter
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: app_starter
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d app_starter"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Migrate Drizzle schema
+        run: pnpm db:migrate
+
+      - name: Build app
+        run: pnpm build
 
       - name: Install Playwright (Chromium)
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests
-        env:
-          CI: true
         run: pnpm test:e2e
 
       - name: Upload Playwright artifacts

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -11,7 +11,7 @@ if (!databaseUrl) {
 
 export default defineConfig({
   out: './drizzle',
-  schema: './src/server/db/schema.ts',
+  schema: './src/server/db',
   dialect: 'postgresql',
   dbCredentials: {
     url: databaseUrl,

--- a/apps/web/drizzle/0001_flat_slyde.sql
+++ b/apps/web/drizzle/0001_flat_slyde.sql
@@ -1,0 +1,53 @@
+CREATE TABLE "account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp,
+	"refresh_token_expires_at" timestamp,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "account_userId_idx" ON "account" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "session_userId_idx" ON "session" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "verification_identifier_idx" ON "verification" USING btree ("identifier");

--- a/apps/web/drizzle/meta/0001_snapshot.json
+++ b/apps/web/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,406 @@
+{
+  "id": "697f79f7-35af-48bd-9b37-4e8277654913",
+  "prevId": "9419248f-969d-4f10-b87a-44280e24d29d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776945353821,
       "tag": "0000_amazing_crusher_hogan",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776953629456,
+      "tag": "0001_flat_slyde",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/e2e/auth-todos.spec.ts
+++ b/apps/web/e2e/auth-todos.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+test("users can sign up and persist todos against the production server", async ({
+	page,
+}) => {
+	const email = `playwright-${Date.now()}@example.com`;
+	const todoName = `Persisted todo ${Date.now()}`;
+
+	await page.goto("/signup");
+
+	await page.getByLabel("Name").fill("Playwright User");
+	await page.getByLabel("Email").fill(email);
+	await page.getByLabel("Password").fill("playwright-password-123");
+	await page.getByRole("button", { name: "Create account" }).click();
+
+	await expect(page).toHaveURL(/\/todos$/);
+	await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+
+	await page.getByLabel("New todo").fill(todoName);
+	await page.getByRole("button", { name: "Add todo" }).click();
+
+	await expect(page.getByText(todoName, { exact: true })).toBeVisible();
+
+	await page.reload();
+
+	await expect(page.getByText(todoName, { exact: true })).toBeVisible();
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -3,6 +3,11 @@ import { defineConfig, devices } from "@playwright/test";
 const host = process.env.PLAYWRIGHT_WEB_HOST ?? "127.0.0.1";
 const port = Number(process.env.PLAYWRIGHT_WEB_PORT ?? 4173);
 const baseURL = `http://${host}:${port}`;
+const serverMode = process.env.PLAYWRIGHT_SERVER_MODE ?? "dev";
+const isBuildServer = serverMode === "build";
+const webServerCommand = isBuildServer
+	? "pnpm start"
+	: `pnpm exec vite dev --host ${host} --port ${port}`;
 
 export default defineConfig({
 	testDir: "./e2e",
@@ -22,20 +27,23 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: `pnpm exec vite dev --host ${host} --port ${port}`,
+		command: webServerCommand,
 		env: {
 			...process.env,
 			BETTER_AUTH_URL: process.env.BETTER_AUTH_URL ?? baseURL,
 			BETTER_AUTH_SECRET:
-				process.env.BETTER_AUTH_SECRET ?? "playwright-test-secret",
+				process.env.BETTER_AUTH_SECRET ??
+				"playwright-test-secret-with-adequate-length",
 			DATABASE_URL:
 				process.env.DATABASE_URL ??
 				"postgresql://postgres:postgres@127.0.0.1:5432/app_starter",
+			HOST: process.env.HOST ?? host,
+			PORT: process.env.PORT ?? String(port),
 			SERVER_URL: process.env.SERVER_URL ?? baseURL,
 			VITE_APP_TITLE: process.env.VITE_APP_TITLE ?? "app-starter",
 		},
 		url: baseURL,
-		reuseExistingServer: !process.env.CI,
+		reuseExistingServer: serverMode === "dev" && !process.env.CI,
 		timeout: 120 * 1000,
 	},
 });

--- a/apps/web/src/server/auth/index.ts
+++ b/apps/web/src/server/auth/index.ts
@@ -3,10 +3,17 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
 
 import { db } from "#/server/db";
+import { account, session, user, verification } from "#/server/db/auth-schema";
 
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: "pg",
+		schema: {
+			account,
+			session,
+			user,
+			verification,
+		},
 	}),
 	baseURL: process.env.BETTER_AUTH_URL,
 	emailAndPassword: {

--- a/apps/web/src/server/db/auth-schema.ts
+++ b/apps/web/src/server/db/auth-schema.ts
@@ -1,0 +1,93 @@
+import { relations } from "drizzle-orm";
+import { boolean, index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const user = pgTable("user", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	email: text("email").notNull().unique(),
+	emailVerified: boolean("email_verified").default(false).notNull(),
+	image: text("image"),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at")
+		.defaultNow()
+		.$onUpdate(() => new Date())
+		.notNull(),
+});
+
+export const session = pgTable(
+	"session",
+	{
+		id: text("id").primaryKey(),
+		expiresAt: timestamp("expires_at").notNull(),
+		token: text("token").notNull().unique(),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+		updatedAt: timestamp("updated_at")
+			.$onUpdate(() => new Date())
+			.notNull(),
+		ipAddress: text("ip_address"),
+		userAgent: text("user_agent"),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+	},
+	(table) => [index("session_userId_idx").on(table.userId)],
+);
+
+export const account = pgTable(
+	"account",
+	{
+		id: text("id").primaryKey(),
+		accountId: text("account_id").notNull(),
+		providerId: text("provider_id").notNull(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		accessToken: text("access_token"),
+		refreshToken: text("refresh_token"),
+		idToken: text("id_token"),
+		accessTokenExpiresAt: timestamp("access_token_expires_at"),
+		refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+		scope: text("scope"),
+		password: text("password"),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+		updatedAt: timestamp("updated_at")
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [index("account_userId_idx").on(table.userId)],
+);
+
+export const verification = pgTable(
+	"verification",
+	{
+		id: text("id").primaryKey(),
+		identifier: text("identifier").notNull(),
+		value: text("value").notNull(),
+		expiresAt: timestamp("expires_at").notNull(),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+		updatedAt: timestamp("updated_at")
+			.defaultNow()
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [index("verification_identifier_idx").on(table.identifier)],
+);
+
+export const userRelations = relations(user, ({ many }) => ({
+	sessions: many(session),
+	accounts: many(account),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+	user: one(user, {
+		fields: [session.userId],
+		references: [user.id],
+	}),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+	user: one(user, {
+		fields: [account.userId],
+		references: [user.id],
+	}),
+}));

--- a/apps/web/src/server/db/schema.ts
+++ b/apps/web/src/server/db/schema.ts
@@ -5,3 +5,5 @@ export const todos = pgTable("todos", {
 	name: text().notNull(),
 	createdAt: timestamp("created_at").defaultNow(),
 });
+
+export * from "./auth-schema";


### PR DESCRIPTION
## Summary
- split web CI into parallel `build` and `e2e` jobs
- run Playwright against the built Nitro server with Postgres-backed migrations
- add Better Auth Drizzle schema wiring plus a checked-in auth migration so signup works end to end

## Why
The template CI only exercised shallow Playwright smoke tests against the dev server. This change adds full-stack coverage for the production server path while keeping wall-clock time lower by running the build and E2E jobs in parallel.

## Impact
- CI now validates `check`, unit tests, production build, and production-server E2E
- Playwright covers signup and persisted todo creation against a real Postgres database
- Better Auth now has explicit Drizzle models in the app runtime instead of relying on missing schema definitions

## Validation
- `pnpm --filter web check`
- `pnpm --filter web test`
- `pnpm --filter web build`
- fresh Postgres container + `pnpm db:migrate` + `pnpm build` + `pnpm test:e2e`

## Notes
- Docker smoke testing was intentionally left out of this PR
- Vitest still reports a hanging-process warning after passing; that behavior was pre-existing and was not changed here