### PR TITLE
[codex] split web build workflow

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,57 @@
+name: Web Build
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/web-build.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/web-build.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting and lint rules
+        run: pnpm --filter web check
+
+      - name: Run unit tests
+        run: pnpm --filter web test
+
+      - name: Build app
+        env:
+          BETTER_AUTH_SECRET: playwright-test-secret-with-adequate-length
+          BETTER_AUTH_URL: http://127.0.0.1:4173
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/app_starter
+          SERVER_URL: http://127.0.0.1:4173
+          VITE_APP_TITLE: app-starter
+        run: pnpm --filter web build

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,4 +1,4 @@
-name: Web CI
+name: Web E2E
 
 on:
   pull_request:
@@ -19,43 +19,6 @@ on:
       - "pnpm-workspace.yaml"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check formatting and lint rules
-        run: pnpm --filter web check
-
-      - name: Run unit tests
-        run: pnpm --filter web test
-
-      - name: Build app
-        env:
-          BETTER_AUTH_SECRET: playwright-test-secret-with-adequate-length
-          BETTER_AUTH_URL: http://127.0.0.1:4173
-          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/app_starter
-          SERVER_URL: http://127.0.0.1:4173
-          VITE_APP_TITLE: app-starter
-        run: pnpm --filter web build
-
   e2e:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## What changed
- moved the `build` job out of `.github/workflows/web-e2e.yml` into a dedicated `.github/workflows/web-build.yml`
- kept the existing build steps and path filters in the new workflow
- renamed the remaining e2e workflow display name from `Web CI` to `Web E2E` to match its new scope

## Why
- separates build validation from the end-to-end workflow so each CI concern lives in its own file
- makes the Actions layout clearer and keeps future edits scoped to the workflow they affect

## Validation
- parsed both workflow files locally with `PyYAML`
