### PR TITLE
Fix todo auth scoping and drizzle migration metadata

### DIFF
--- a/apps/web/drizzle/0002_user_scoped_todos.sql
+++ b/apps/web/drizzle/0002_user_scoped_todos.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "todos" ADD COLUMN "user_id" text;
+--> statement-breakpoint
+DELETE FROM "todos";
+--> statement-breakpoint
+ALTER TABLE "todos" ALTER COLUMN "user_id" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "todos" ADD CONSTRAINT "todos_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "todos_user_id_idx" ON "todos" USING btree ("user_id");

--- a/apps/web/drizzle/meta/0002_snapshot.json
+++ b/apps/web/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,442 @@
+{
+  "id": "35d9dd1a-d649-4b7f-a6b2-e19e7b24f4c3",
+  "prevId": "697f79f7-35af-48bd-9b37-4e8277654913",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.todos": {
+      "name": "todos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "todos_user_id_idx": {
+          "name": "todos_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todos_user_id_user_id_fk": {
+          "name": "todos_user_id_user_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776953629456,
       "tag": "0001_flat_slyde",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777017600000,
+      "tag": "0002_user_scoped_todos",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/orpc-client.ts
+++ b/apps/web/src/lib/orpc-client.ts
@@ -1,7 +1,6 @@
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
-import type { RouterClient } from "@orpc/server";
-import { createRouterClient } from "@orpc/server";
+import { createRouterClient, type RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";

--- a/apps/web/src/routes/api/$.ts
+++ b/apps/web/src/routes/api/$.ts
@@ -56,7 +56,9 @@ const handler = new OpenAPIHandler(router, {
 async function handle({ request }: { request: Request }) {
 	const { response } = await handler.handle(request, {
 		prefix: "/api",
-		context: {},
+		context: {
+			headers: request.headers,
+		},
 	});
 
 	return response ?? new Response("Not Found", { status: 404 });

--- a/apps/web/src/routes/api/rpc/$.ts
+++ b/apps/web/src/routes/api/rpc/$.ts
@@ -9,7 +9,9 @@ const handler = new RPCHandler(router);
 async function handle({ request }: { request: Request }) {
 	const { response } = await handler.handle(request, {
 		prefix: "/api/rpc",
-		context: {},
+		context: {
+			headers: request.headers,
+		},
 	});
 
 	return response ?? new Response("Not Found", { status: 404 });

--- a/apps/web/src/routes/todos.tsx
+++ b/apps/web/src/routes/todos.tsx
@@ -1,29 +1,43 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { authClient } from "#/lib/auth-client";
 import { orpc } from "#/lib/orpc-client";
+
+function isUnauthorizedError(error: unknown) {
+	return error instanceof Error && error.message === "Unauthorized";
+}
 
 export const Route = createFileRoute("/todos")({
 	loader: async ({ context }) => {
-		await context.queryClient.ensureQueryData(
-			orpc.listTodos.queryOptions({
-				input: {},
-			}),
-		);
+		try {
+			await context.queryClient.ensureQueryData(
+				orpc.listTodos.queryOptions({
+					input: {},
+				}),
+			);
+		} catch (error) {
+			if (!isUnauthorizedError(error)) {
+				throw error;
+			}
+		}
 	},
 	component: TodosPage,
 });
 
 function TodosPage() {
 	const queryClient = useQueryClient();
+	const { data: session, isPending: isSessionPending } =
+		authClient.useSession();
 	const [name, setName] = useState("");
 	const [error, setError] = useState<string | null>(null);
-	const todosQuery = useQuery(
-		orpc.listTodos.queryOptions({
+	const todosQuery = useQuery({
+		...orpc.listTodos.queryOptions({
 			input: {},
 		}),
-	);
+		enabled: !!session?.user,
+	});
 	const addTodo = useMutation(
 		orpc.addTodo.mutationOptions({
 			onSuccess: async () => {
@@ -37,6 +51,45 @@ function TodosPage() {
 			},
 		}),
 	);
+
+	if (isSessionPending) {
+		return (
+			<main className="app-shell">
+				<section className="page-wrap">
+					<section className="hello-card">
+						<p className="hello-label">Todo Slice</p>
+						<h1>Loading your workspace…</h1>
+					</section>
+				</section>
+			</main>
+		);
+	}
+
+	if (!session?.user) {
+		return (
+			<main className="app-shell">
+				<section className="page-wrap">
+					<section className="hello-card">
+						<p className="hello-label">Todo Slice</p>
+						<h1>Sign in to access your todos.</h1>
+						<p>
+							Todos are now scoped to the signed-in user, so this route only
+							loads persisted records after authentication.
+						</p>
+
+						<div className="not-found-actions">
+							<Link to="/login" className="inline-cta">
+								Log in
+							</Link>
+							<Link to="/signup" className="nav-link">
+								Create account
+							</Link>
+						</div>
+					</section>
+				</section>
+			</main>
+		);
+	}
 
 	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();

--- a/apps/web/src/server/auth/index.ts
+++ b/apps/web/src/server/auth/index.ts
@@ -5,6 +5,20 @@ import { tanstackStartCookies } from "better-auth/tanstack-start";
 import { db } from "#/server/db";
 import { account, session, user, verification } from "#/server/db/auth-schema";
 
+const betterAuthUrl = process.env.BETTER_AUTH_URL;
+if (!betterAuthUrl) {
+	throw new Error("BETTER_AUTH_URL is required");
+}
+
+const betterAuthSecret = process.env.BETTER_AUTH_SECRET;
+if (!betterAuthSecret) {
+	throw new Error("BETTER_AUTH_SECRET is required");
+}
+
+if (betterAuthSecret.length < 32) {
+	throw new Error("BETTER_AUTH_SECRET must be at least 32 characters");
+}
+
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: "pg",
@@ -15,12 +29,11 @@ export const auth = betterAuth({
 			verification,
 		},
 	}),
-	baseURL: process.env.BETTER_AUTH_URL,
+	baseURL: betterAuthUrl,
+	secret: betterAuthSecret,
 	emailAndPassword: {
 		enabled: true,
 	},
-	trustedOrigins: process.env.BETTER_AUTH_URL
-		? [process.env.BETTER_AUTH_URL]
-		: undefined,
+	trustedOrigins: [betterAuthUrl],
 	plugins: [tanstackStartCookies()],
 });

--- a/apps/web/src/server/db/schema.ts
+++ b/apps/web/src/server/db/schema.ts
@@ -1,9 +1,28 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { index, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
 
-export const todos = pgTable("todos", {
-	id: serial().primaryKey(),
-	name: text().notNull(),
-	createdAt: timestamp("created_at").defaultNow(),
-});
+import { user } from "./auth-schema";
+
+export const todos = pgTable(
+	"todos",
+	{
+		id: serial().primaryKey(),
+		name: text().notNull(),
+		createdAt: timestamp("created_at").defaultNow(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, {
+				onDelete: "cascade",
+			}),
+	},
+	(table) => [index("todos_user_id_idx").on(table.userId)],
+);
+
+export const todosRelations = relations(todos, ({ one }) => ({
+	user: one(user, {
+		fields: [todos.userId],
+		references: [user.id],
+	}),
+}));
 
 export * from "./auth-schema";

--- a/apps/web/src/server/orpc/router/todos.test.ts
+++ b/apps/web/src/server/orpc/router/todos.test.ts
@@ -6,21 +6,53 @@ vi.mock("#/server/todos", () => ({
 	createPersistedTodo: vi.fn(),
 	listPersistedTodos: vi.fn(),
 }));
+vi.mock("#/server/auth", () => ({
+	auth: {
+		api: {
+			getSession: vi.fn(),
+		},
+	},
+}));
 
 describe("todo handlers", async () => {
 	const serverTodos = await import("#/server/todos");
+	const serverAuth = await import("#/server/auth");
+	const mockSession = {
+		session: {
+			id: "session-1",
+			createdAt: new Date("2026-04-23T00:00:00.000Z"),
+			updatedAt: new Date("2026-04-23T00:00:00.000Z"),
+			userId: "user-1",
+			expiresAt: new Date("2026-04-24T00:00:00.000Z"),
+			token: "session-token",
+		},
+		user: {
+			id: "user-1",
+			name: "Test User",
+			email: "test@example.com",
+			emailVerified: false,
+			createdAt: new Date("2026-04-23T00:00:00.000Z"),
+			updatedAt: new Date("2026-04-23T00:00:00.000Z"),
+		},
+	};
 
 	it("lists persisted todos", async () => {
+		vi.mocked(serverAuth.auth.api.getSession).mockResolvedValue(mockSession);
+
 		vi.mocked(serverTodos.listPersistedTodos).mockResolvedValueOnce([
 			{ id: 1, name: "First todo" },
 		]);
 
-		await expect(listTodosHandler()).resolves.toEqual([
-			{ id: 1, name: "First todo" },
-		]);
+		await expect(
+			listTodosHandler({
+				context: { headers: new Headers() },
+			}),
+		).resolves.toEqual([{ id: 1, name: "First todo" }]);
 	});
 
 	it("creates a persisted todo", async () => {
+		vi.mocked(serverAuth.auth.api.getSession).mockResolvedValue(mockSession);
+
 		vi.mocked(serverTodos.createPersistedTodo).mockResolvedValueOnce({
 			id: 2,
 			name: "Second todo",
@@ -29,6 +61,7 @@ describe("todo handlers", async () => {
 		await expect(
 			addTodoHandler({
 				input: { name: "Second todo" },
+				context: { headers: new Headers() },
 			}),
 		).resolves.toEqual({
 			id: 2,

--- a/apps/web/src/server/orpc/router/todos.ts
+++ b/apps/web/src/server/orpc/router/todos.ts
@@ -1,22 +1,47 @@
 import { os } from "@orpc/server";
 import * as z from "zod";
 
+import { auth } from "#/server/auth";
 import { createPersistedTodo, listPersistedTodos } from "#/server/todos";
 
 const TodoInputSchema = z.object({
 	name: z.string().trim().min(1).max(120),
 });
 
-export async function listTodosHandler() {
-	return listPersistedTodos();
+type OrpcContext = {
+	headers?: Headers;
+};
+
+async function getAuthenticatedUserId(context: OrpcContext | undefined) {
+	if (!context?.headers) {
+		throw new Error("Unauthorized");
+	}
+
+	const session = await auth.api.getSession({ headers: context.headers });
+
+	if (!session?.user?.id) {
+		throw new Error("Unauthorized");
+	}
+
+	return session.user.id;
+}
+
+export async function listTodosHandler({ context }: { context?: OrpcContext }) {
+	const userId = await getAuthenticatedUserId(context);
+
+	return listPersistedTodos(userId);
 }
 
 export async function addTodoHandler({
 	input,
+	context,
 }: {
 	input: z.infer<typeof TodoInputSchema>;
+	context?: OrpcContext;
 }) {
-	return createPersistedTodo(input.name);
+	const userId = await getAuthenticatedUserId(context);
+
+	return createPersistedTodo(input.name, userId);
 }
 
 export const listTodos = os.input(z.object({})).handler(listTodosHandler);

--- a/apps/web/src/server/todos.ts
+++ b/apps/web/src/server/todos.ts
@@ -1,23 +1,30 @@
-import { asc } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 
 import { db } from "#/server/db";
 import { todos } from "#/server/db/schema";
 
-export async function listPersistedTodos() {
+export async function listPersistedTodos(userId: string) {
 	return db
 		.select({
 			id: todos.id,
 			name: todos.name,
 		})
 		.from(todos)
+		.where(eq(todos.userId, userId))
 		.orderBy(asc(todos.createdAt), asc(todos.id));
 }
 
-export async function createPersistedTodo(name: string) {
-	const [todo] = await db.insert(todos).values({ name }).returning({
-		id: todos.id,
-		name: todos.name,
-	});
+export async function createPersistedTodo(name: string, userId: string) {
+	const [todo] = await db
+		.insert(todos)
+		.values({
+			name,
+			userId,
+		})
+		.returning({
+			id: todos.id,
+			name: todos.name,
+		});
 
 	return todo;
 }


### PR DESCRIPTION
## Summary
- scope persisted todos to the authenticated user and forward request headers into oRPC auth checks
- restore safe /todos behavior for signed-out users and keep the server oRPC client synchronous for SSR
- register the new Drizzle migration metadata and enforce non-null todo ownership at the schema layer