### PR TITLE
Add local TanStack agent skills

### DIFF
--- a/.agents/skills/db-core/SKILL.md
+++ b/.agents/skills/db-core/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: db-core
+description: >
+  TanStack DB core concepts: createCollection with queryCollectionOptions,
+  electricCollectionOptions, powerSyncCollectionOptions, rxdbCollectionOptions,
+  trailbaseCollectionOptions, localOnlyCollectionOptions. Live queries via
+  query builder (from, where, join, select, groupBy, orderBy, limit). Optimistic
+  mutations with draft proxy (collection.insert, collection.update,
+  collection.delete). createOptimisticAction, createTransaction,
+  createPacedMutations. Entry point for all TanStack DB skills.
+type: core
+library: db
+library_version: '0.6.0'
+---
+
+# TanStack DB — Core Concepts
+
+TanStack DB is a reactive client-side data store. It loads data into typed
+collections from any backend (REST APIs, sync engines, local storage), provides
+sub-millisecond live queries via differential dataflow, and supports instant
+optimistic mutations with automatic rollback.
+
+Framework packages (`@tanstack/react-db`, `@tanstack/vue-db`, `@tanstack/svelte-db`,
+`@tanstack/solid-db`) re-export everything from `@tanstack/db` plus framework-specific
+hooks. In framework projects, import from the framework package directly.
+`@tanstack/angular-db` is the exception -- import operators from `@tanstack/db` separately.
+
+## Sub-Skills
+
+| Need to...                                       | Read                                                 |
+| ------------------------------------------------ | ---------------------------------------------------- |
+| Create a collection, pick an adapter, add schema | db-core/collection-setup/SKILL.md                    |
+| Query data with where, join, groupBy, select     | db-core/live-queries/SKILL.md                        |
+| Insert, update, delete with optimistic UI        | db-core/mutations-optimistic/SKILL.md                |
+| Build a custom sync adapter                      | db-core/custom-adapter/SKILL.md                      |
+| Persist collections to SQLite (offline cache)    | db-core/persistence/SKILL.md                         |
+| Preload collections in route loaders             | meta-framework/SKILL.md                              |
+| Add offline transaction queueing                 | offline/SKILL.md (in @tanstack/offline-transactions) |
+
+For framework-specific hooks:
+
+| Framework | Read                |
+| --------- | ------------------- |
+| React     | react-db/SKILL.md   |
+| Vue       | vue-db/SKILL.md     |
+| Svelte    | svelte-db/SKILL.md  |
+| Solid     | solid-db/SKILL.md   |
+| Angular   | angular-db/SKILL.md |
+
+## Quick Decision Tree
+
+- Setting up for the first time? → db-core/collection-setup
+- Building queries on collection data? → db-core/live-queries
+- Writing data / handling optimistic state? → db-core/mutations-optimistic
+- Using React hooks? → react-db
+- Preloading in route loaders (Start, Next, Remix)? → meta-framework
+- Building an adapter for a new backend? → db-core/custom-adapter
+- Persisting collections to SQLite? → db-core/persistence
+- Need offline transaction persistence? → offline
+
+## Version
+
+Targets @tanstack/db v0.6.0.

--- a/.agents/skills/db-core/SKILL.md
+++ b/.agents/skills/db-core/SKILL.md
@@ -37,22 +37,24 @@ hooks. In framework projects, import from the framework package directly.
 | Preload collections in route loaders             | meta-framework/SKILL.md                              |
 | Add offline transaction queueing                 | offline/SKILL.md (in @tanstack/offline-transactions) |
 
-For framework-specific hooks:
+For framework-specific hooks, use the framework package APIs directly. This repo
+currently installs local DB skills for `db-core*` and `meta-framework`; it does
+not include separate framework-specific DB skills.
 
-| Framework | Read                |
-| --------- | ------------------- |
-| React     | react-db/SKILL.md   |
-| Vue       | vue-db/SKILL.md     |
-| Svelte    | svelte-db/SKILL.md  |
-| Solid     | solid-db/SKILL.md   |
-| Angular   | angular-db/SKILL.md |
+| Framework | Package                  | Hook/API examples                                      |
+| --------- | ------------------------ | ------------------------------------------------------ |
+| React     | `@tanstack/react-db`     | `useLiveQuery`, `useLiveSuspenseQuery`, `useCollection` |
+| Vue       | `@tanstack/vue-db`       | framework-specific live query composables              |
+| Svelte    | `@tanstack/svelte-db`    | framework-specific live query stores                   |
+| Solid     | `@tanstack/solid-db`     | framework-specific live query primitives               |
+| Angular   | `@tanstack/angular-db`   | Angular DB APIs; import query operators from `@tanstack/db` |
 
 ## Quick Decision Tree
 
 - Setting up for the first time? → db-core/collection-setup
 - Building queries on collection data? → db-core/live-queries
 - Writing data / handling optimistic state? → db-core/mutations-optimistic
-- Using React hooks? → react-db
+- Using React hooks? → use `@tanstack/react-db` APIs with `db-core/live-queries`
 - Preloading in route loaders (Start, Next, Remix)? → meta-framework
 - Building an adapter for a new backend? → db-core/custom-adapter
 - Persisting collections to SQLite? → db-core/persistence

--- a/.agents/skills/db-core/collection-setup/SKILL.md
+++ b/.agents/skills/db-core/collection-setup/SKILL.md
@@ -1,0 +1,446 @@
+---
+name: db-core/collection-setup
+description: >
+  Creating typed collections with createCollection. Adapter selection:
+  queryCollectionOptions (REST/TanStack Query), electricCollectionOptions
+  (ElectricSQL real-time sync), powerSyncCollectionOptions (PowerSync SQLite),
+  rxdbCollectionOptions (RxDB), trailbaseCollectionOptions (TrailBase),
+  localOnlyCollectionOptions, localStorageCollectionOptions. CollectionConfig
+  options: getKey, schema, sync, gcTime, autoIndex (default off), defaultIndexType,
+  syncMode (eager/on-demand, plus progressive for Electric). StandardSchema validation
+  with Zod/Valibot/ArkType. Collection lifecycle (idle/loading/ready/error).
+  Adapter-specific sync patterns including Electric txid tracking, Query direct
+  writes, and PowerSync query-driven sync with onLoad/onLoadSubset hooks.
+type: sub-skill
+library: db
+library_version: '0.6.0'
+sources:
+  - 'TanStack/db:docs/overview.md'
+  - 'TanStack/db:docs/guides/schemas.md'
+  - 'TanStack/db:docs/collections/query-collection.md'
+  - 'TanStack/db:docs/collections/electric-collection.md'
+  - 'TanStack/db:docs/collections/powersync-collection.md'
+  - 'TanStack/db:docs/collections/rxdb-collection.md'
+  - 'TanStack/db:docs/collections/trailbase-collection.md'
+  - 'TanStack/db:packages/db/src/collection/index.ts'
+---
+
+This skill builds on db-core. Read it first for the overall mental model.
+
+# Collection Setup & Schema
+
+## Setup
+
+```ts
+import { createCollection } from '@tanstack/react-db'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
+import { QueryClient } from '@tanstack/query-core'
+import { z } from 'zod'
+
+const queryClient = new QueryClient()
+
+const todoSchema = z.object({
+  id: z.number(),
+  text: z.string(),
+  completed: z.boolean().default(false),
+  created_at: z
+    .union([z.string(), z.date()])
+    .transform((val) => (typeof val === 'string' ? new Date(val) : val)),
+})
+
+const todoCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: async () => {
+      const res = await fetch('/api/todos')
+      return res.json()
+    },
+    queryClient,
+    getKey: (item) => item.id,
+    schema: todoSchema,
+    onInsert: async ({ transaction }) => {
+      await api.todos.create(transaction.mutations[0].modified)
+      await todoCollection.utils.refetch()
+    },
+    onUpdate: async ({ transaction }) => {
+      const mut = transaction.mutations[0]
+      await api.todos.update(mut.key, mut.changes)
+      await todoCollection.utils.refetch()
+    },
+    onDelete: async ({ transaction }) => {
+      await api.todos.delete(transaction.mutations[0].key)
+      await todoCollection.utils.refetch()
+    },
+  }),
+)
+```
+
+## Choosing an Adapter
+
+| Backend                          | Adapter                         | Package                             |
+| -------------------------------- | ------------------------------- | ----------------------------------- |
+| REST API / TanStack Query        | `queryCollectionOptions`        | `@tanstack/query-db-collection`     |
+| ElectricSQL (real-time Postgres) | `electricCollectionOptions`     | `@tanstack/electric-db-collection`  |
+| PowerSync (SQLite offline)       | `powerSyncCollectionOptions`    | `@tanstack/powersync-db-collection` |
+| RxDB (reactive database)         | `rxdbCollectionOptions`         | `@tanstack/rxdb-db-collection`      |
+| TrailBase (event streaming)      | `trailbaseCollectionOptions`    | `@tanstack/trailbase-db-collection` |
+| No backend (UI state)            | `localOnlyCollectionOptions`    | `@tanstack/db`                      |
+| Browser localStorage             | `localStorageCollectionOptions` | `@tanstack/db`                      |
+
+If the user specifies a backend (e.g. Electric, PowerSync), use that adapter directly. Only use `localOnlyCollectionOptions` when there is no backend yet — the collection API is uniform, so swapping to a real adapter later only changes the options creator.
+
+## Sync Modes
+
+```ts
+queryCollectionOptions({
+  syncMode: 'eager', // default — loads all data upfront
+  // syncMode: "on-demand", // loads only what live queries request
+  // syncMode: "progressive", // (Electric only) query subset first, full sync in background
+})
+```
+
+| Mode          | Best for                                                       | Data size |
+| ------------- | -------------------------------------------------------------- | --------- |
+| `eager`       | Mostly-static datasets                                         | <10k rows |
+| `on-demand`   | Search, catalogs, large tables                                 | >50k rows |
+| `progressive` | Collaborative apps needing instant first paint (Electric only) | Any       |
+
+## Indexing
+
+Indexing is opt-in. The `autoIndex` option defaults to `"off"`. To enable automatic indexing, set `autoIndex: "eager"` and provide a `defaultIndexType`:
+
+```ts
+import { BasicIndex } from '@tanstack/db'
+
+createCollection(
+  queryCollectionOptions({
+    autoIndex: 'eager',
+    defaultIndexType: BasicIndex,
+    // ...
+  }),
+)
+```
+
+Without `defaultIndexType`, setting `autoIndex: "eager"` throws a `CollectionConfigurationError`. You can also create indexes manually with `collection.createIndex()` and remove them with `collection.removeIndex()`.
+
+## Core Patterns
+
+### Local-only collection for prototyping
+
+```ts
+import {
+  createCollection,
+  localOnlyCollectionOptions,
+} from '@tanstack/react-db'
+
+const todoCollection = createCollection(
+  localOnlyCollectionOptions({
+    getKey: (item) => item.id,
+    initialData: [{ id: 1, text: 'Learn TanStack DB', completed: false }],
+  }),
+)
+```
+
+### Schema with type transformations
+
+```ts
+const schema = z.object({
+  id: z.number(),
+  title: z.string(),
+  due_date: z
+    .union([z.string(), z.date()])
+    .transform((val) => (typeof val === 'string' ? new Date(val) : val)),
+  priority: z.number().default(0),
+})
+```
+
+Use `z.union([z.string(), z.date()])` for transformed fields — this ensures `TInput` is a superset of `TOutput` so that `update()` works correctly with the draft proxy.
+
+### ElectricSQL with txid tracking
+
+Always use a schema with Electric — without one, the collection types as `Record<string, unknown>`.
+
+```ts
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { z } from 'zod'
+
+const todoSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  completed: z.boolean(),
+  created_at: z.coerce.date(),
+})
+
+const todoCollection = createCollection(
+  electricCollectionOptions({
+    schema: todoSchema,
+    shapeOptions: { url: '/api/electric/todos' },
+    getKey: (item) => item.id,
+    onInsert: async ({ transaction }) => {
+      const res = await api.todos.create(transaction.mutations[0].modified)
+      return { txid: res.txid }
+    },
+  }),
+)
+```
+
+The returned `txid` tells the collection to hold optimistic state until Electric streams back that transaction. See the [Electric adapter reference](references/electric-adapter.md) for the full dual-path pattern (schema + parser).
+
+## Common Mistakes
+
+### CRITICAL queryFn returning empty array deletes all data
+
+Wrong:
+
+```ts
+queryCollectionOptions({
+  queryFn: async () => {
+    const res = await fetch('/api/todos?status=active')
+    return res.json() // returns [] when no active todos — deletes everything
+  },
+})
+```
+
+Correct:
+
+```ts
+queryCollectionOptions({
+  queryFn: async () => {
+    const res = await fetch('/api/todos') // fetch complete state
+    return res.json()
+  },
+  // Use on-demand mode + live query where() for filtering
+  syncMode: 'on-demand',
+})
+```
+
+`queryFn` result is treated as complete server state. Returning `[]` means "server has no items", deleting all existing collection data.
+
+Source: docs/collections/query-collection.md
+
+### CRITICAL Not using the correct adapter for your backend
+
+Wrong:
+
+```ts
+const todoCollection = createCollection(
+  localOnlyCollectionOptions({
+    getKey: (item) => item.id,
+  }),
+)
+// Manually fetching and inserting...
+```
+
+Correct:
+
+```ts
+const todoCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: async () => fetch('/api/todos').then((r) => r.json()),
+    queryClient,
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+Each backend has a dedicated adapter that handles sync, mutation handlers, and utilities. Using `localOnlyCollectionOptions` or bare `createCollection` for a real backend bypasses all of this.
+
+Source: docs/overview.md
+
+### CRITICAL Electric txid queried outside mutation transaction
+
+Wrong:
+
+```ts
+// Backend handler
+app.post('/api/todos', async (req, res) => {
+  const txid = await generateTxId(sql) // WRONG: separate transaction
+  await sql`INSERT INTO todos ${sql(req.body)}`
+  res.json({ txid })
+})
+```
+
+Correct:
+
+```ts
+app.post('/api/todos', async (req, res) => {
+  let txid
+  await sql.begin(async (tx) => {
+    txid = await generateTxId(tx) // CORRECT: same transaction
+    await tx`INSERT INTO todos ${tx(req.body)}`
+  })
+  res.json({ txid })
+})
+```
+
+`pg_current_xact_id()` must be queried inside the same SQL transaction as the mutation. Otherwise the txid doesn't match and `awaitTxId` times out (default 5 seconds).
+
+Source: docs/collections/electric-collection.md
+
+### CRITICAL queryFn returning partial data without merging
+
+Wrong:
+
+```ts
+queryCollectionOptions({
+  queryFn: async () => {
+    const newItems = await fetch('/api/todos?since=' + lastSync)
+    return newItems.json() // only new items — everything else deleted
+  },
+})
+```
+
+Correct:
+
+```ts
+queryCollectionOptions({
+  queryFn: async (ctx) => {
+    const existing = ctx.queryClient.getQueryData(['todos']) || []
+    const newItems = await fetch('/api/todos?since=' + lastSync).then((r) =>
+      r.json(),
+    )
+    return [...existing, ...newItems]
+  },
+})
+```
+
+`queryFn` result replaces all collection data. For incremental fetches, merge with existing data.
+
+Source: docs/collections/query-collection.md
+
+### HIGH Using async schema validation
+
+Wrong:
+
+```ts
+const schema = z.object({
+  email: z.string().refine(async (val) => {
+    const exists = await checkEmail(val)
+    return !exists
+  }),
+})
+```
+
+Correct:
+
+```ts
+const schema = z.object({
+  email: z.string().email(),
+})
+// Do async validation in the mutation handler instead
+```
+
+Schema validation must be synchronous. Async validation throws `SchemaMustBeSynchronousError` at mutation time.
+
+Source: packages/db/src/collection/mutations.ts:101
+
+### HIGH getKey returning undefined for some items
+
+Wrong:
+
+```ts
+createCollection(
+  queryCollectionOptions({
+    getKey: (item) => item.metadata.id, // undefined if metadata missing
+  }),
+)
+```
+
+Correct:
+
+```ts
+createCollection(
+  queryCollectionOptions({
+    getKey: (item) => item.id, // always present
+  }),
+)
+```
+
+`getKey` must return a defined value for every item. Throws `UndefinedKeyError` otherwise.
+
+Source: packages/db/src/collection/mutations.ts:148
+
+### HIGH TInput not a superset of TOutput with schema transforms
+
+Wrong:
+
+```ts
+const schema = z.object({
+  created_at: z.string().transform((val) => new Date(val)),
+})
+// update() fails — draft.created_at is Date but schema only accepts string
+```
+
+Correct:
+
+```ts
+const schema = z.object({
+  created_at: z
+    .union([z.string(), z.date()])
+    .transform((val) => (typeof val === 'string' ? new Date(val) : val)),
+})
+```
+
+When a schema transforms types, `TInput` must accept both the pre-transform and post-transform types for `update()` to work with the draft proxy.
+
+Source: docs/guides/schemas.md
+
+### HIGH React Native missing crypto.randomUUID polyfill
+
+TanStack DB uses `crypto.randomUUID()` internally. React Native doesn't provide this. Install `react-native-random-uuid` and import it at your app entry point.
+
+Source: docs/overview.md
+
+### MEDIUM Providing both explicit type parameter and schema
+
+Wrong:
+
+```ts
+createCollection<Todo>(queryCollectionOptions({ schema: todoSchema, ... }))
+```
+
+Correct:
+
+```ts
+createCollection(queryCollectionOptions({ schema: todoSchema, ... }))
+```
+
+When a schema is provided, the collection infers types from it. An explicit generic creates conflicting type constraints.
+
+Source: docs/overview.md
+
+### MEDIUM Direct writes overridden by next query sync
+
+Wrong:
+
+```ts
+todoCollection.utils.writeInsert(newItem)
+// Next queryFn execution replaces all data, losing the direct write
+```
+
+Correct:
+
+```ts
+todoCollection.utils.writeInsert(newItem)
+// Use staleTime to prevent immediate refetch
+// Or return { refetch: false } from mutation handlers
+```
+
+Direct writes update the collection immediately, but the next `queryFn` returns complete server state which overwrites them.
+
+Source: docs/collections/query-collection.md
+
+## References
+
+- [TanStack Query adapter](references/query-adapter.md)
+- [ElectricSQL adapter](references/electric-adapter.md)
+- [PowerSync adapter](references/powersync-adapter.md)
+- [RxDB adapter](references/rxdb-adapter.md)
+- [TrailBase adapter](references/trailbase-adapter.md)
+- [Local adapters (local-only, localStorage)](references/local-adapters.md)
+- [Schema validation patterns](references/schema-patterns.md)
+
+See also: db-core/mutations-optimistic/SKILL.md — mutation handlers configured here execute during mutations.
+
+See also: db-core/custom-adapter/SKILL.md — for building your own adapter.

--- a/.agents/skills/db-core/collection-setup/references/electric-adapter.md
+++ b/.agents/skills/db-core/collection-setup/references/electric-adapter.md
@@ -1,0 +1,238 @@
+# Electric Adapter Reference
+
+## Install
+
+```bash
+pnpm add @tanstack/electric-db-collection @tanstack/react-db
+```
+
+## Required Config
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+
+const collection = createCollection(
+  electricCollectionOptions({
+    shapeOptions: { url: '/api/todos' },
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+- `shapeOptions` -- ElectricSQL ShapeStream config; `url` is the proxy URL to Electric
+- `getKey` -- extracts unique key from each item
+
+## Optional Config
+
+| Option                | Default | Description                                         |
+| --------------------- | ------- | --------------------------------------------------- |
+| `id`                  | (none)  | Unique collection identifier                        |
+| `schema`              | (none)  | StandardSchema validator                            |
+| `shapeOptions.params` | (none)  | Additional shape params (e.g. `{ table: 'todos' }`) |
+| `onInsert`            | (none)  | Persistence handler; should return `{ txid }`       |
+| `onUpdate`            | (none)  | Persistence handler; should return `{ txid }`       |
+| `onDelete`            | (none)  | Persistence handler; should return `{ txid }`       |
+
+## Three Sync Strategies
+
+### 1. Txid Return (Recommended)
+
+Handler returns `{ txid }`. Client waits for that txid in the Electric stream.
+
+```typescript
+onInsert: async ({ transaction }) => {
+  const response = await api.todos.create(transaction.mutations[0].modified)
+  return { txid: response.txid }
+},
+```
+
+### 2. awaitMatch (Custom Match)
+
+Use when txids are unavailable. Import `isChangeMessage` to match on message content.
+
+```typescript
+import { isChangeMessage } from "@tanstack/electric-db-collection"
+
+onInsert: async ({ transaction, collection }) => {
+  const newItem = transaction.mutations[0].modified
+  await api.todos.create(newItem)
+  await collection.utils.awaitMatch(
+    (message) =>
+      isChangeMessage(message) &&
+      message.headers.operation === "insert" &&
+      message.value.text === newItem.text,
+    5000 // timeout ms, defaults to 3000
+  )
+},
+```
+
+### 3. Simple Timeout (Prototyping)
+
+```typescript
+onInsert: async ({ transaction }) => {
+  await api.todos.create(transaction.mutations[0].modified)
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+},
+```
+
+## Utility Methods (`collection.utils`)
+
+- `awaitTxId(txid, timeout?)` -- wait for txid in Electric stream; default timeout 5s
+- `awaitMatch(matchFn, timeout?)` -- wait for message matching predicate; default timeout 3000ms
+
+### Helper Exports
+
+```typescript
+import {
+  isChangeMessage,
+  isControlMessage,
+} from '@tanstack/electric-db-collection'
+// isChangeMessage(msg) -- true for insert/update/delete
+// isControlMessage(msg) -- true for up-to-date/must-refetch
+```
+
+## generateTxId Backend Pattern
+
+The txid **must** be queried inside the same Postgres transaction as the mutation.
+
+```typescript
+async function generateTxId(tx: any): Promise<number> {
+  const result = await tx`SELECT pg_current_xact_id()::xid::text as txid`
+  const txid = result[0]?.txid
+  if (txid === undefined) throw new Error('Failed to get transaction ID')
+  return parseInt(txid, 10)
+}
+
+async function createTodo(data) {
+  let txid!: number
+  const result = await sql.begin(async (tx) => {
+    txid = await generateTxId(tx) // INSIDE the transaction
+    const [todo] = await tx`INSERT INTO todos ${tx(data)} RETURNING *`
+    return todo
+  })
+  return { todo: result, txid }
+}
+```
+
+Querying txid outside the transaction produces a mismatched txid -- `awaitTxId` stalls indefinitely.
+
+## Schema vs Parser: Two Separate Paths
+
+When using Electric with a schema, data enters the collection via **two independent paths**:
+
+1. **Sync path** — Electric's `ShapeStream` applies the `parser` from `shapeOptions`. The schema is NOT applied to synced data.
+2. **Mutation path** — `insert()` and `update()` run through the collection schema. The parser is not involved.
+
+For types that need transformation (e.g., `timestamptz`), you need BOTH configured:
+
+```typescript
+const todosCollection = createCollection(
+  electricCollectionOptions({
+    schema: z.object({
+      id: z.string(),
+      text: z.string(),
+      completed: z.boolean(), // Electric auto-parses bools
+      created_at: z.coerce.date(), // mutation path: coerce string → Date
+    }),
+    shapeOptions: {
+      url: '/api/todos',
+      parser: {
+        timestamptz: (value: string) => new Date(value), // sync path: parse incoming strings
+      },
+    },
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+### Postgres → Electric type handling
+
+| PG type        | Electric auto-parses? | Schema needed?    | Parser needed?                                      |
+| -------------- | --------------------- | ----------------- | --------------------------------------------------- |
+| `text`, `uuid` | Yes (string)          | `z.string()`      | No                                                  |
+| `int4`, `int8` | Yes (number)          | `z.number()`      | No                                                  |
+| `bool`         | Yes (boolean)         | `z.boolean()`     | No                                                  |
+| `timestamptz`  | No (stays string)     | `z.coerce.date()` | Yes — `parser: { timestamptz: (v) => new Date(v) }` |
+| `jsonb`        | Yes (parsed object)   | As needed         | No                                                  |
+
+Note: `z.coerce.date()` is Zod-specific. Other StandardSchema libraries have their own coercion patterns.
+
+## Proxy Route
+
+Electric collections connect to a proxy URL (`shapeOptions.url`), not directly to Electric. Your app server must forward shape requests to Electric, passing through the Electric protocol query params.
+
+The proxy route must:
+
+1. Accept GET requests at the URL you specify in `shapeOptions.url`
+2. Forward all query parameters (these are Electric protocol params like `offset`, `handle`, `live`, etc.)
+3. Proxy the response (SSE stream) back to the client
+4. Optionally add authentication headers or filter params
+
+Implementation depends on your framework — use `createServerFn` in TanStack Start, API routes in Next.js, `loader` in Remix, etc. See the `@electric-sql/client` skills for proxy route examples:
+
+```bash
+npx @electric-sql/client intent list
+```
+
+## Electric Client Skills
+
+For deeper Electric-specific guidance (ShapeStream config, shape filtering, etc.), load the Electric client's built-in skills:
+
+```bash
+npx @electric-sql/client intent list
+```
+
+## Debug Logging
+
+```javascript
+localStorage.debug = 'ts/db:electric'
+```
+
+## Complete Example
+
+Always use a schema — types are inferred automatically, avoiding generic placement confusion.
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import { z } from 'zod'
+
+const todoSchema = z.object({
+  id: z.string(),
+  text: z.string().min(1),
+  completed: z.boolean(),
+  created_at: z.coerce.date(),
+})
+
+const todosCollection = createCollection(
+  electricCollectionOptions({
+    id: 'todos',
+    schema: todoSchema,
+    getKey: (item) => item.id,
+    shapeOptions: {
+      url: '/api/todos',
+      params: { table: 'todos' },
+      parser: {
+        timestamptz: (value: string) => new Date(value), // sync path
+      },
+    },
+    onInsert: async ({ transaction }) => {
+      const response = await api.todos.create(transaction.mutations[0].modified)
+      return { txid: response.txid }
+    },
+    onUpdate: async ({ transaction }) => {
+      const { original, changes } = transaction.mutations[0]
+      const response = await api.todos.update({
+        where: { id: original.id },
+        data: changes,
+      })
+      return { txid: response.txid }
+    },
+    onDelete: async ({ transaction }) => {
+      const response = await api.todos.delete(transaction.mutations[0].key)
+      return { txid: response.txid }
+    },
+  }),
+)
+```

--- a/.agents/skills/db-core/collection-setup/references/local-adapters.md
+++ b/.agents/skills/db-core/collection-setup/references/local-adapters.md
@@ -1,0 +1,220 @@
+# Local Adapters Reference
+
+Both adapters are included in the core package.
+
+## Install
+
+```bash
+pnpm add @tanstack/react-db
+```
+
+---
+
+## localOnlyCollectionOptions
+
+In-memory only. No persistence. No cross-tab sync.
+
+### Required Config
+
+```typescript
+import {
+  createCollection,
+  localOnlyCollectionOptions,
+} from '@tanstack/react-db'
+
+const collection = createCollection(
+  localOnlyCollectionOptions({
+    id: 'ui-state',
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+- `id` -- unique collection identifier
+- `getKey` -- extracts unique key from each item
+
+### Optional Config
+
+| Option        | Default | Description                            |
+| ------------- | ------- | -------------------------------------- |
+| `schema`      | (none)  | StandardSchema validator               |
+| `initialData` | (none)  | Array of items to populate on creation |
+| `onInsert`    | (none)  | Handler before confirming inserts      |
+| `onUpdate`    | (none)  | Handler before confirming updates      |
+| `onDelete`    | (none)  | Handler before confirming deletes      |
+
+### Direct Mutations
+
+```typescript
+collection.insert({ id: 'theme', mode: 'dark' })
+collection.update('theme', (draft) => {
+  draft.mode = 'light'
+})
+collection.delete('theme')
+```
+
+### initialData
+
+```typescript
+localOnlyCollectionOptions({
+  id: 'ui-state',
+  getKey: (item) => item.id,
+  initialData: [
+    { id: 'sidebar', isOpen: false },
+    { id: 'theme', mode: 'light' },
+  ],
+})
+```
+
+### acceptMutations in Manual Transactions
+
+When using `createTransaction`, call `collection.utils.acceptMutations(transaction)` in `mutationFn`:
+
+```typescript
+import { createTransaction } from '@tanstack/react-db'
+
+const tx = createTransaction({
+  mutationFn: async ({ transaction }) => {
+    // Handle server mutations first, then:
+    localData.utils.acceptMutations(transaction)
+  },
+})
+tx.mutate(() => {
+  localData.insert({ id: 'draft-1', data: '...' })
+})
+await tx.commit()
+```
+
+---
+
+## localStorageCollectionOptions
+
+Persists to `localStorage`. Cross-tab sync via storage events. Survives reloads.
+
+### Required Config
+
+```typescript
+import {
+  createCollection,
+  localStorageCollectionOptions,
+} from '@tanstack/react-db'
+
+const collection = createCollection(
+  localStorageCollectionOptions({
+    id: 'user-preferences',
+    storageKey: 'app-user-prefs',
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+- `id` -- unique collection identifier
+- `storageKey` -- localStorage key for all collection data
+- `getKey` -- extracts unique key from each item
+
+### Optional Config
+
+| Option            | Default        | Description                                                          |
+| ----------------- | -------------- | -------------------------------------------------------------------- |
+| `schema`          | (none)         | StandardSchema validator                                             |
+| `storage`         | `localStorage` | Custom storage (`sessionStorage` or any localStorage-compatible API) |
+| `storageEventApi` | `window`       | Event API for cross-tab sync                                         |
+| `onInsert`        | (none)         | Handler on insert                                                    |
+| `onUpdate`        | (none)         | Handler on update                                                    |
+| `onDelete`        | (none)         | Handler on delete                                                    |
+
+### Using sessionStorage
+
+```typescript
+localStorageCollectionOptions({
+  id: 'session-data',
+  storageKey: 'session-key',
+  storage: sessionStorage,
+  getKey: (item) => item.id,
+})
+```
+
+### Custom Storage Backend
+
+Provide any object with `getItem`, `setItem`, `removeItem`:
+
+```typescript
+const encryptedStorage = {
+  getItem: (key) => {
+    const v = localStorage.getItem(key)
+    return v ? decrypt(v) : null
+  },
+  setItem: (key, value) => localStorage.setItem(key, encrypt(value)),
+  removeItem: (key) => localStorage.removeItem(key),
+}
+localStorageCollectionOptions({
+  id: 'secure',
+  storageKey: 'enc-key',
+  storage: encryptedStorage,
+  getKey: (i) => i.id,
+})
+```
+
+### acceptMutations
+
+Same as LocalOnly -- call `collection.utils.acceptMutations(transaction)` in manual transactions.
+
+---
+
+## Comparison
+
+| Feature         | LocalOnly        | LocalStorage |
+| --------------- | ---------------- | ------------ |
+| Persistence     | None (in-memory) | localStorage |
+| Cross-tab sync  | No               | Yes          |
+| Survives reload | No               | Yes          |
+| Performance     | Fastest          | Fast         |
+| Size limits     | Memory           | ~5-10MB      |
+
+## Complete Example
+
+```typescript
+import {
+  createCollection,
+  localOnlyCollectionOptions,
+  localStorageCollectionOptions,
+} from '@tanstack/react-db'
+import { z } from 'zod'
+
+// In-memory UI state
+const modalState = createCollection(
+  localOnlyCollectionOptions({
+    id: 'modal-state',
+    getKey: (item) => item.id,
+    initialData: [
+      { id: 'confirm-delete', isOpen: false },
+      { id: 'settings', isOpen: false },
+    ],
+  }),
+)
+
+// Persistent user prefs
+const userPrefs = createCollection(
+  localStorageCollectionOptions({
+    id: 'user-preferences',
+    storageKey: 'app-user-prefs',
+    getKey: (item) => item.id,
+    schema: z.object({
+      id: z.string(),
+      theme: z.enum(['light', 'dark', 'auto']),
+      language: z.string(),
+      notifications: z.boolean(),
+    }),
+  }),
+)
+
+modalState.update('settings', (draft) => {
+  draft.isOpen = true
+})
+userPrefs.insert({
+  id: 'current-user',
+  theme: 'dark',
+  language: 'en',
+  notifications: true,
+})
+```

--- a/.agents/skills/db-core/collection-setup/references/powersync-adapter.md
+++ b/.agents/skills/db-core/collection-setup/references/powersync-adapter.md
@@ -1,0 +1,245 @@
+# PowerSync Adapter Reference
+
+## Install
+
+```bash
+pnpm add @tanstack/powersync-db-collection @powersync/web @journeyapps/wa-sqlite
+```
+
+## Required Config
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { powerSyncCollectionOptions } from '@tanstack/powersync-db-collection'
+import { Schema, Table, column, PowerSyncDatabase } from '@powersync/web'
+
+const APP_SCHEMA = new Schema({
+  documents: new Table({
+    name: column.text,
+    author: column.text,
+    created_at: column.text,
+    archived: column.integer,
+  }),
+})
+
+const db = new PowerSyncDatabase({
+  database: { dbFilename: 'app.sqlite' },
+  schema: APP_SCHEMA,
+})
+
+const documentsCollection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+  }),
+)
+```
+
+- `database` -- `PowerSyncDatabase` instance
+- `table` -- PowerSync `Table` from schema (provides `getKey` and type inference)
+
+## Optional Config (with defaults)
+
+| Option                   | Default | Description                                                                           |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------- |
+| `schema`                 | (none)  | StandardSchema for mutation validation                                                |
+| `deserializationSchema`  | (none)  | Transforms SQLite types to output types; required when input types differ from SQLite |
+| `onDeserializationError` | (none)  | Fatal error handler; **required** when using `schema` or `deserializationSchema`      |
+| `serializer`             | (none)  | Per-field functions to serialize output types back to SQLite                          |
+| `syncBatchSize`          | `1000`  | Batch size for initial sync                                                           |
+
+### SQLite Type Mapping
+
+| PowerSync Column | TypeScript Type  |
+| ---------------- | ---------------- |
+| `column.text`    | `string \| null` |
+| `column.integer` | `number \| null` |
+| `column.real`    | `number \| null` |
+
+All columns nullable by default. `id: string` is always included automatically.
+
+## Conversions (4 patterns)
+
+### 1. Type Inference Only (no schema)
+
+```typescript
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+  }),
+)
+// Input/Output: { id: string, name: string | null, created_at: string | null, ... }
+```
+
+### 2. Schema Validation (same SQLite types)
+
+```typescript
+const schema = z.object({
+  id: z.string(),
+  name: z.string().min(3),
+  author: z.string(),
+  created_at: z.string(),
+  archived: z.number(),
+})
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+    schema,
+    onDeserializationError: (error) => {
+      /* fatal */
+    },
+  }),
+)
+```
+
+### 3. Transform SQLite to Rich Output Types
+
+```typescript
+const schema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  created_at: z
+    .string()
+    .nullable()
+    .transform((val) => (val ? new Date(val) : null)),
+  archived: z
+    .number()
+    .nullable()
+    .transform((val) => (val != null ? val > 0 : null)),
+})
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+    schema,
+    onDeserializationError: (error) => {
+      /* fatal */
+    },
+    serializer: { created_at: (value) => (value ? value.toISOString() : null) },
+  }),
+)
+// Input:  { created_at: string | null, ... }
+// Output: { created_at: Date | null, archived: boolean | null, ... }
+```
+
+### 4. Custom Input + Output with deserializationSchema
+
+```typescript
+const schema = z.object({
+  id: z.string(),
+  name: z.string(),
+  created_at: z.date(),
+  archived: z.boolean(),
+})
+const deserializationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  created_at: z.string().transform((val) => new Date(val)),
+  archived: z.number().transform((val) => val > 0),
+})
+const collection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.documents,
+    schema,
+    deserializationSchema,
+    onDeserializationError: (error) => {
+      /* fatal */
+    },
+  }),
+)
+// Input:  { created_at: Date, archived: boolean }
+// Output: { created_at: Date, archived: boolean }
+```
+
+## Metadata Tracking
+
+Enable on the table, then pass metadata with operations:
+
+```typescript
+const APP_SCHEMA = new Schema({
+  documents: new Table({ name: column.text }, { trackMetadata: true }),
+})
+
+await collection.insert(
+  { id: crypto.randomUUID(), name: 'Report' },
+  { metadata: { source: 'web-app', userId: 'user-123' } },
+).isPersisted.promise
+```
+
+Metadata appears as `entry.metadata` (stringified JSON) in PowerSync `CrudEntry`.
+
+## Advanced Transactions
+
+```typescript
+import { createTransaction } from '@tanstack/react-db'
+import { PowerSyncTransactor } from '@tanstack/powersync-db-collection'
+
+const tx = createTransaction({
+  autoCommit: false,
+  mutationFn: async ({ transaction }) => {
+    await new PowerSyncTransactor({ database: db }).applyTransaction(
+      transaction,
+    )
+  },
+})
+tx.mutate(() => {
+  documentsCollection.insert({
+    id: crypto.randomUUID(),
+    name: 'Doc 1',
+    created_at: new Date().toISOString(),
+  })
+})
+await tx.commit()
+await tx.isPersisted.promise
+```
+
+## On-Demand Sync Mode
+
+PowerSync supports `on-demand` sync mode (query-driven sync), where only rows matching active live query predicates are loaded from SQLite into the collection. This can be combined with Sync Streams via `onLoad` (eager) or `onLoadSubset` (on-demand) hooks to also control which data the PowerSync Service syncs to the device. Use `extractSimpleComparisons` or `parseWhereExpression` to derive Sync Stream parameters dynamically from live query predicates.
+
+## Complete Example
+
+```typescript
+import { Schema, Table, column, PowerSyncDatabase } from '@powersync/web'
+import { createCollection } from '@tanstack/react-db'
+import { powerSyncCollectionOptions } from '@tanstack/powersync-db-collection'
+import { z } from 'zod'
+
+const APP_SCHEMA = new Schema({
+  tasks: new Table({
+    title: column.text,
+    due_date: column.text,
+    completed: column.integer,
+  }),
+})
+const db = new PowerSyncDatabase({
+  database: { dbFilename: 'app.sqlite' },
+  schema: APP_SCHEMA,
+})
+
+const taskSchema = z.object({
+  id: z.string(),
+  title: z.string().nullable(),
+  due_date: z
+    .string()
+    .nullable()
+    .transform((val) => (val ? new Date(val) : null)),
+  completed: z
+    .number()
+    .nullable()
+    .transform((val) => (val != null ? val > 0 : null)),
+})
+
+const tasksCollection = createCollection(
+  powerSyncCollectionOptions({
+    database: db,
+    table: APP_SCHEMA.props.tasks,
+    schema: taskSchema,
+    onDeserializationError: (error) => console.error('Fatal:', error),
+    syncBatchSize: 500,
+  }),
+)
+```

--- a/.agents/skills/db-core/collection-setup/references/query-adapter.md
+++ b/.agents/skills/db-core/collection-setup/references/query-adapter.md
@@ -1,0 +1,215 @@
+# Query Adapter Reference
+
+## Install
+
+```bash
+pnpm add @tanstack/query-db-collection @tanstack/query-core @tanstack/db
+```
+
+## Required Config
+
+```typescript
+import { QueryClient } from '@tanstack/query-core'
+import { createCollection } from '@tanstack/db'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
+
+const queryClient = new QueryClient()
+const collection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: async () => fetch('/api/todos').then((r) => r.json()),
+    queryClient,
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+- `queryKey` -- TanStack Query cache key
+- `queryFn` -- fetches data; must be provided (throws `QueryFnRequiredError` if missing)
+- `queryClient` -- `QueryClient` instance
+- `getKey` -- extracts unique key from each item
+
+## Optional Config (with defaults)
+
+| Option            | Default      | Description                                     |
+| ----------------- | ------------ | ----------------------------------------------- |
+| `id`              | (none)       | Unique collection identifier                    |
+| `schema`          | (none)       | StandardSchema validator                        |
+| `select`          | (none)       | Extracts array items when wrapped with metadata |
+| `enabled`         | `true`       | Whether query runs automatically                |
+| `refetchInterval` | `0`          | Polling interval in ms; 0 = disabled            |
+| `retry`           | (TQ default) | Retry config for failed queries                 |
+| `retryDelay`      | (TQ default) | Delay between retries                           |
+| `staleTime`       | (TQ default) | How long data is considered fresh               |
+| `meta`            | (none)       | Metadata passed to queryFn context              |
+| `startSync`       | `true`       | Start syncing immediately                       |
+| `syncMode`        | (none)       | Set `"on-demand"` for predicate push-down       |
+
+### Persistence Handlers
+
+```typescript
+onInsert: async ({ transaction }) => {
+  await api.createTodos(transaction.mutations.map((m) => m.modified))
+  // return nothing or { refetch: true } to trigger refetch
+  // return { refetch: false } to skip refetch
+},
+onUpdate: async ({ transaction }) => {
+  await api.updateTodos(transaction.mutations.map((m) => ({ id: m.key, changes: m.changes })))
+},
+onDelete: async ({ transaction }) => {
+  await api.deleteTodos(transaction.mutations.map((m) => m.key))
+},
+```
+
+## Utility Methods (`collection.utils`)
+
+- `refetch(opts?)` -- manual refetch; `opts.throwOnError` (default `false`); bypasses `enabled: false`
+- `writeInsert(data)` -- insert directly to synced store (bypasses optimistic system)
+- `writeUpdate(data)` -- update directly in synced store
+- `writeDelete(keys)` -- delete directly from synced store
+- `writeUpsert(data)` -- insert or update directly
+- `writeBatch(callback)` -- multiple write ops atomically
+
+Direct writes bypass optimistic updates, do NOT trigger refetches, and update TQ cache immediately.
+
+```typescript
+collection.utils.writeBatch(() => {
+  collection.utils.writeInsert({ id: '1', text: 'Buy milk' })
+  collection.utils.writeUpdate({ id: '2', completed: true })
+  collection.utils.writeDelete('3')
+})
+```
+
+## Predicate Push-Down (syncMode: "on-demand")
+
+Query predicates (where, orderBy, limit, offset) passed to `queryFn` via `ctx.meta.loadSubsetOptions`.
+
+```typescript
+import { parseLoadSubsetOptions } from '@tanstack/query-db-collection'
+
+queryFn: async (ctx) => {
+  const { filters, sorts, limit, offset } = parseLoadSubsetOptions(
+    ctx.meta?.loadSubsetOptions,
+  )
+  // filters: [{ field: ['category'], operator: 'eq', value: 'electronics' }]
+  // sorts: [{ field: ['price'], direction: 'asc', nulls: 'last' }]
+}
+```
+
+### Expression Helpers (from `@tanstack/db`)
+
+- `parseLoadSubsetOptions(opts)` -- returns `{ filters, sorts, limit, offset }`
+- `parseWhereExpression(expr, { handlers })` -- custom handlers per operator
+- `parseOrderByExpression(expr)` -- returns `[{ field, direction, nulls }]`
+- `extractSimpleComparisons(expr)` -- flat AND-ed comparisons only
+
+Supported operators: `eq`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `in`
+
+## Dynamic queryKey
+
+```typescript
+queryKey: (opts) => {
+  const parsed = parseLoadSubsetOptions(opts)
+  const key = ["products"]
+  parsed.filters.forEach((f) => key.push(`${f.field.join(".")}-${f.operator}-${f.value}`))
+  if (parsed.limit) key.push(`limit-${parsed.limit}`)
+  return key
+},
+```
+
+## Complete Example
+
+```typescript
+import { QueryClient } from '@tanstack/query-core'
+import { createCollection } from '@tanstack/react-db'
+import {
+  queryCollectionOptions,
+  parseLoadSubsetOptions,
+} from '@tanstack/query-db-collection'
+
+const queryClient = new QueryClient()
+
+const productsCollection = createCollection(
+  queryCollectionOptions({
+    id: 'products',
+    queryKey: ['products'],
+    queryClient,
+    getKey: (item) => item.id,
+    syncMode: 'on-demand',
+    queryFn: async (ctx) => {
+      const { filters, sorts, limit } = parseLoadSubsetOptions(
+        ctx.meta?.loadSubsetOptions,
+      )
+      const params = new URLSearchParams()
+      filters.forEach(({ field, operator, value }) => {
+        params.set(`${field.join('.')}_${operator}`, String(value))
+      })
+      if (sorts.length > 0) {
+        params.set(
+          'sort',
+          sorts.map((s) => `${s.field.join('.')}:${s.direction}`).join(','),
+        )
+      }
+      if (limit) params.set('limit', String(limit))
+      return fetch(`/api/products?${params}`).then((r) => r.json())
+    },
+    onInsert: async ({ transaction }) => {
+      const serverItems = await api.createProducts(
+        transaction.mutations.map((m) => m.modified),
+      )
+      productsCollection.utils.writeBatch(() => {
+        serverItems.forEach((item) =>
+          productsCollection.utils.writeInsert(item),
+        )
+      })
+      return { refetch: false }
+    },
+    onUpdate: async ({ transaction }) => {
+      await api.updateProducts(
+        transaction.mutations.map((m) => ({ id: m.key, changes: m.changes })),
+      )
+    },
+    onDelete: async ({ transaction }) => {
+      await api.deleteProducts(transaction.mutations.map((m) => m.key))
+    },
+  }),
+)
+```
+
+## Common Mistakes
+
+### HIGH Function-based queryKey without shared prefix
+
+Wrong:
+
+```ts
+queryCollectionOptions({
+  queryKey: (opts) => {
+    if (opts.where) {
+      return ['products-filtered', JSON.stringify(opts.where)]
+    }
+    return ['products-all']
+  },
+})
+```
+
+Correct:
+
+```ts
+queryCollectionOptions({
+  queryKey: (opts) => {
+    if (opts.where) {
+      return ['products', JSON.stringify(opts.where)]
+    }
+    return ['products']
+  },
+})
+```
+
+When using a function-based `queryKey`, all derived keys must share the base key (`queryKey({})`) as a prefix. TanStack Query uses prefix matching for cache operations; if derived keys don't share the base prefix, cache updates silently miss entries, leading to stale data.
+
+## Key Behaviors
+
+- `queryFn` result is treated as **complete state** -- missing items are deleted
+- Empty array from `queryFn` deletes all items
+- Direct writes update TQ cache but are overridden by subsequent `queryFn` results

--- a/.agents/skills/db-core/collection-setup/references/rxdb-adapter.md
+++ b/.agents/skills/db-core/collection-setup/references/rxdb-adapter.md
@@ -1,0 +1,152 @@
+# RxDB Adapter Reference
+
+## Install
+
+```bash
+pnpm add @tanstack/rxdb-db-collection rxdb @tanstack/react-db
+```
+
+## Required Config
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { rxdbCollectionOptions } from '@tanstack/rxdb-db-collection'
+
+const todosCollection = createCollection(
+  rxdbCollectionOptions({
+    rxCollection: db.todos,
+  }),
+)
+```
+
+- `rxCollection` -- the underlying RxDB `RxCollection` instance
+
+## Optional Config (with defaults)
+
+| Option          | Default                 | Description                                                                                        |
+| --------------- | ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `id`            | (none)                  | Unique collection identifier                                                                       |
+| `schema`        | (none)                  | StandardSchema validator (RxDB has its own validation; this adds TanStack DB-side validation)      |
+| `startSync`     | `true`                  | Start ingesting RxDB data immediately                                                              |
+| `syncBatchSize` | `1000`                  | Max documents per batch during initial sync from RxDB; only affects initial load, not live updates |
+| `onInsert`      | (default: `bulkUpsert`) | Override default insert persistence                                                                |
+| `onUpdate`      | (default: `patch`)      | Override default update persistence                                                                |
+| `onDelete`      | (default: `bulkRemove`) | Override default delete persistence                                                                |
+
+## Key Behavior: String Keys
+
+RxDB primary keys are always strings. The `getKey` function is derived from the RxDB schema's `primaryKey` field automatically. All key values will be strings.
+
+## RxDB Setup (prerequisite)
+
+```typescript
+import { createRxDatabase } from 'rxdb/plugins/core'
+import { getRxStorageLocalstorage } from 'rxdb/plugins/storage-localstorage'
+
+const db = await createRxDatabase({
+  name: 'my-app',
+  storage: getRxStorageLocalstorage(),
+})
+
+await db.addCollections({
+  todos: {
+    schema: {
+      title: 'todos',
+      version: 0,
+      type: 'object',
+      primaryKey: 'id',
+      properties: {
+        id: { type: 'string', maxLength: 100 },
+        text: { type: 'string' },
+        completed: { type: 'boolean' },
+      },
+      required: ['id', 'text', 'completed'],
+    },
+  },
+})
+```
+
+## Backend Sync (optional, RxDB-managed)
+
+Replication is configured directly on the RxDB collection, independent of TanStack DB. Changes from replication flow into the TanStack DB collection via RxDB's change stream automatically.
+
+```typescript
+import { replicateRxCollection } from 'rxdb/plugins/replication'
+
+const replicationState = replicateRxCollection({
+  collection: db.todos,
+  pull: { handler: myPullHandler },
+  push: { handler: myPushHandler },
+})
+```
+
+## Data Flow
+
+- Writes via `todosCollection.insert/update/delete` persist to RxDB
+- Direct RxDB writes (or replication changes) flow into the TanStack collection via change streams
+- Initial sync loads data in batches of `syncBatchSize`
+- Ongoing updates stream one by one via RxDB's change feed
+
+## Indexes
+
+RxDB schema indexes do not affect TanStack DB query performance (queries run in-memory). Indexes may still matter if you query RxDB directly, use filtered replication, or selectively load subsets.
+
+## Complete Example
+
+```typescript
+import { createRxDatabase } from 'rxdb/plugins/core'
+import { getRxStorageLocalstorage } from 'rxdb/plugins/storage-localstorage'
+import { createCollection } from '@tanstack/react-db'
+import { rxdbCollectionOptions } from '@tanstack/rxdb-db-collection'
+import { z } from 'zod'
+
+type Todo = { id: string; text: string; completed: boolean }
+
+const db = await createRxDatabase({
+  name: 'my-todos',
+  storage: getRxStorageLocalstorage(),
+})
+
+await db.addCollections({
+  todos: {
+    schema: {
+      title: 'todos',
+      version: 0,
+      type: 'object',
+      primaryKey: 'id',
+      properties: {
+        id: { type: 'string', maxLength: 100 },
+        text: { type: 'string' },
+        completed: { type: 'boolean' },
+      },
+      required: ['id', 'text', 'completed'],
+    },
+  },
+})
+
+const todoSchema = z.object({
+  id: z.string(),
+  text: z.string().min(1),
+  completed: z.boolean(),
+})
+
+const todosCollection = createCollection(
+  rxdbCollectionOptions({
+    rxCollection: db.todos,
+    schema: todoSchema,
+    startSync: true,
+    syncBatchSize: 500,
+  }),
+)
+
+// Usage
+todosCollection.insert({
+  id: crypto.randomUUID(),
+  text: 'Buy milk',
+  completed: false,
+})
+todosCollection.update('some-id', (draft) => {
+  draft.completed = true
+})
+todosCollection.delete('some-id')
+```

--- a/.agents/skills/db-core/collection-setup/references/schema-patterns.md
+++ b/.agents/skills/db-core/collection-setup/references/schema-patterns.md
@@ -1,0 +1,215 @@
+# Schema Patterns Reference
+
+## StandardSchema Integration
+
+TanStack DB accepts any [StandardSchema](https://standardschema.dev)-compatible library via the `schema` option.
+
+### Supported Libraries
+
+- [Zod](https://zod.dev), [Valibot](https://valibot.dev), [ArkType](https://arktype.io), [Effect Schema](https://effect.website/docs/schema/introduction/)
+
+## TInput vs TOutput
+
+- **TInput** -- type accepted by `insert()` and `update()`
+- **TOutput** -- type stored in collection and returned from queries
+
+When no transforms exist, TInput === TOutput.
+
+```typescript
+const schema = z.object({
+  id: z.string(),
+  created_at: z.string().transform((val) => new Date(val)),
+})
+// TInput:  { id: string, created_at: string }
+// TOutput: { id: string, created_at: Date }
+```
+
+## Union Pattern for Transforms (Required)
+
+When a schema transforms A to B, TInput **must** accept both A and B. During `update()`, the draft contains TOutput data.
+
+```typescript
+// WRONG -- update() fails because draft.created_at is Date but schema expects string
+z.string().transform((val) => new Date(val))
+
+// CORRECT
+z.union([z.string(), z.date()]).transform((val) =>
+  typeof val === 'string' ? new Date(val) : val,
+)
+// TInput: string | Date, TOutput: Date
+```
+
+## Defaults
+
+```typescript
+const schema = z.object({
+  id: z.string(),
+  text: z.string(),
+  completed: z.boolean().default(false),
+  priority: z.number().default(0),
+  tags: z.array(z.string()).default([]),
+  created_at: z.date().default(() => new Date()),
+})
+// insert({ id: "1", text: "Task" }) -- missing fields auto-filled
+```
+
+## Computed Fields
+
+```typescript
+const schema = z
+  .object({
+    id: z.string(),
+    first_name: z.string(),
+    last_name: z.string(),
+  })
+  .transform((data) => ({
+    ...data,
+    full_name: `${data.first_name} ${data.last_name}`,
+  }))
+```
+
+## Combining Defaults with Transforms
+
+```typescript
+const schema = z.object({
+  created_at: z
+    .string()
+    .default(() => new Date().toISOString())
+    .transform((val) => new Date(val)),
+})
+```
+
+## Validation Examples
+
+```typescript
+// Basic constraints
+z.string().min(3).max(100)
+z.string().email()
+z.number().int().positive()
+z.enum(['active', 'inactive'])
+z.array(z.string()).min(1)
+
+// Optional/nullable
+z.string().optional() // can be omitted
+z.string().nullable() // can be null
+
+// Cross-field
+z.object({ start: z.string(), end: z.string() }).refine(
+  (d) => new Date(d.end) > new Date(d.start),
+  'End must be after start',
+)
+
+// Custom
+z.string().refine((v) => /^[a-zA-Z0-9_]+$/.test(v), 'Alphanumeric only')
+```
+
+## SchemaValidationError
+
+```typescript
+import { SchemaValidationError } from '@tanstack/db'
+
+try {
+  collection.insert({ id: '1', email: 'bad', age: -5 })
+} catch (error) {
+  if (error instanceof SchemaValidationError) {
+    error.type // "insert" or "update"
+    error.message // "Validation failed with 2 issues"
+    error.issues // [{ path: ["email"], message: "Invalid email" }, ...]
+  }
+}
+```
+
+## Scope: Schema vs Sync — Two Separate Paths
+
+**Schemas validate client mutations only** (`insert()`, `update()`). Synced data from backends (Electric, PowerSync, etc.) bypasses the schema entirely.
+
+This means for types that need transformation (e.g., `timestamptz`):
+
+- **Sync path**: handled by the adapter's parser (e.g., Electric's `shapeOptions.parser`)
+- **Mutation path**: handled by the Zod schema
+
+You need BOTH configured for full type safety. See electric-adapter.md for the dual-path pattern.
+
+### Simpler date coercion (Zod-specific)
+
+With Zod, `z.coerce.date()` is simpler than the `z.union([z.string(), z.date()]).transform(...)` pattern:
+
+```typescript
+// Zod-specific: z.coerce.date() accepts string, number, or Date as input
+const schema = z.object({
+  created_at: z.coerce.date(),
+})
+// TInput: { created_at: string | number | Date }  (coerce accepts many types)
+// TOutput: { created_at: Date }
+```
+
+This satisfies the TInput-superset-of-TOutput requirement automatically. Other StandardSchema libraries have their own coercion patterns — consult library docs.
+
+### Important
+
+- Validation is synchronous, runs on every mutation
+- Keep transforms simple for performance
+
+## Where TOutput Appears
+
+- Data stored in collection and returned from queries
+- `PendingMutation.modified`
+- Mutation handler `transaction.mutations[].modified`
+
+## Performance
+
+Keep transforms simple -- validation runs synchronously on every mutation.
+
+## Complete Example
+
+```typescript
+import { z } from 'zod'
+import { createCollection, SchemaValidationError } from '@tanstack/react-db'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
+
+const todoSchema = z.object({
+  id: z.string(),
+  text: z.string().min(1, 'Text is required'),
+  completed: z.boolean().default(false),
+  priority: z.enum(['low', 'medium', 'high']).default('medium'),
+  created_at: z
+    .union([z.string(), z.date()])
+    .transform((val) => (typeof val === 'string' ? new Date(val) : val))
+    .default(() => new Date()),
+})
+
+const todosCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: async () => fetch('/api/todos').then((r) => r.json()),
+    queryClient,
+    getKey: (item) => item.id,
+    schema: todoSchema,
+    onInsert: async ({ transaction }) => {
+      const todo = transaction.mutations[0].modified
+      await api.todos.create({
+        ...todo,
+        created_at: todo.created_at.toISOString(),
+      })
+    },
+  }),
+)
+
+// Defaults and transforms applied
+todosCollection.insert({ id: '1', text: 'Buy groceries' })
+// => { id: "1", text: "Buy groceries", completed: false, priority: "medium", created_at: Date }
+
+// Update works -- draft contains TOutput, schema accepts via union
+todosCollection.update('1', (draft) => {
+  draft.completed = true
+})
+
+// Error handling
+try {
+  todosCollection.insert({ id: '2', text: '' })
+} catch (e) {
+  if (e instanceof SchemaValidationError) {
+    console.log(e.issues) // [{ path: ["text"], message: "Text is required" }]
+  }
+}
+```

--- a/.agents/skills/db-core/collection-setup/references/trailbase-adapter.md
+++ b/.agents/skills/db-core/collection-setup/references/trailbase-adapter.md
@@ -1,0 +1,147 @@
+# TrailBase Adapter Reference
+
+## Install
+
+```bash
+pnpm add @tanstack/trailbase-db-collection @tanstack/react-db trailbase
+```
+
+## Required Config
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { trailBaseCollectionOptions } from '@tanstack/trailbase-db-collection'
+import { initClient } from 'trailbase'
+
+const trailBaseClient = initClient('https://your-trailbase-instance.com')
+
+const todosCollection = createCollection(
+  trailBaseCollectionOptions({
+    id: 'todos',
+    recordApi: trailBaseClient.records('todos'),
+    getKey: (item) => item.id,
+  }),
+)
+```
+
+- `id` -- unique collection identifier
+- `recordApi` -- TrailBase Record API instance from `trailBaseClient.records(tableName)`
+- `getKey` -- extracts unique key from each item
+
+## Optional Config
+
+| Option      | Default | Description                                                                       |
+| ----------- | ------- | --------------------------------------------------------------------------------- |
+| `schema`    | (none)  | StandardSchema validator                                                          |
+| `parse`     | (none)  | Object mapping field names to functions that transform data coming FROM TrailBase |
+| `serialize` | (none)  | Object mapping field names to functions that transform data going TO TrailBase    |
+| `onInsert`  | (none)  | Handler called on insert                                                          |
+| `onUpdate`  | (none)  | Handler called on update                                                          |
+| `onDelete`  | (none)  | Handler called on delete                                                          |
+
+## Conversions (parse/serialize)
+
+TrailBase uses different data formats (e.g. Unix timestamps). Use `parse` and `serialize` for field-level transformations.
+
+```typescript
+type SelectTodo = {
+  id: string
+  text: string
+  created_at: number // Unix timestamp from TrailBase
+  completed: boolean
+}
+
+type Todo = {
+  id: string
+  text: string
+  created_at: Date // Rich JS type for app usage
+  completed: boolean
+}
+
+const collection = createCollection<SelectTodo, Todo>(
+  trailBaseCollectionOptions({
+    id: 'todos',
+    recordApi: trailBaseClient.records('todos'),
+    getKey: (item) => item.id,
+    parse: {
+      created_at: (ts) => new Date(ts * 1000),
+    },
+    serialize: {
+      created_at: (date) => Math.floor(date.valueOf() / 1000),
+    },
+  }),
+)
+```
+
+## Real-time Subscriptions
+
+Automatic when `enable_subscriptions` is enabled on the TrailBase server. No additional client config needed -- the collection subscribes to changes automatically.
+
+## Persistence Handlers
+
+```typescript
+onInsert: async ({ transaction }) => {
+  const newItem = transaction.mutations[0].modified
+},
+onUpdate: async ({ transaction }) => {
+  const { original, modified } = transaction.mutations[0]
+},
+onDelete: async ({ transaction }) => {
+  const deletedItem = transaction.mutations[0].original
+},
+```
+
+TrailBase handles persistence through the Record API automatically. Custom handlers are for additional logic only.
+
+## Complete Example
+
+```typescript
+import { createCollection } from '@tanstack/react-db'
+import { trailBaseCollectionOptions } from '@tanstack/trailbase-db-collection'
+import { initClient } from 'trailbase'
+import { z } from 'zod'
+
+const trailBaseClient = initClient('https://your-trailbase-instance.com')
+
+const todoSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  completed: z.boolean(),
+  created_at: z.date(),
+})
+
+type SelectTodo = {
+  id: string
+  text: string
+  completed: boolean
+  created_at: number
+}
+
+type Todo = z.infer<typeof todoSchema>
+
+const todosCollection = createCollection<SelectTodo, Todo>(
+  trailBaseCollectionOptions({
+    id: 'todos',
+    recordApi: trailBaseClient.records('todos'),
+    getKey: (item) => item.id,
+    schema: todoSchema,
+    parse: {
+      created_at: (ts) => new Date(ts * 1000),
+    },
+    serialize: {
+      created_at: (date) => Math.floor(date.valueOf() / 1000),
+    },
+    onInsert: async ({ transaction }) => {
+      console.log('Created:', transaction.mutations[0].modified)
+    },
+  }),
+)
+
+// Usage
+todosCollection.insert({
+  id: crypto.randomUUID(),
+  text: 'Review PR',
+  completed: false,
+  created_at: new Date(),
+})
+```

--- a/.agents/skills/db-core/custom-adapter/SKILL.md
+++ b/.agents/skills/db-core/custom-adapter/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: db-core/custom-adapter
+description: >
+  Building custom collection adapters for new backends. SyncConfig interface:
+  sync function receiving begin, write, commit, markReady, truncate, metadata
+  primitives. ChangeMessage format (insert, update, delete). loadSubset for
+  on-demand sync. LoadSubsetOptions (where, orderBy, limit, cursor). Expression
+  parsing: parseWhereExpression, parseOrderByExpression,
+  extractSimpleComparisons, parseLoadSubsetOptions. Collection options creator
+  pattern. rowUpdateMode (partial vs full). Subscription lifecycle and cleanup
+  functions. Persisted sync metadata API (metadata.row and metadata.collection)
+  for storing per-row and per-collection adapter state.
+type: sub-skill
+library: db
+library_version: '0.6.0'
+sources:
+  - 'TanStack/db:docs/guides/collection-options-creator.md'
+  - 'TanStack/db:packages/db/src/collection/sync.ts'
+---
+
+This skill builds on db-core and db-core/collection-setup. Read those first.
+
+# Custom Adapter Authoring
+
+## Setup
+
+```ts
+import { createCollection } from '@tanstack/db'
+import type { SyncConfig, CollectionConfig } from '@tanstack/db'
+
+interface MyItem {
+  id: string
+  name: string
+}
+
+function myBackendCollectionOptions<T>(config: {
+  endpoint: string
+  getKey: (item: T) => string
+}): CollectionConfig<T, string, {}> {
+  return {
+    getKey: config.getKey,
+    sync: {
+      sync: ({ begin, write, commit, markReady, metadata, collection }) => {
+        let isInitialSyncComplete = false
+        const bufferedEvents: Array<any> = []
+
+        // 1. Subscribe to real-time events FIRST
+        const unsubscribe = myWebSocket.subscribe(config.endpoint, (event) => {
+          if (!isInitialSyncComplete) {
+            bufferedEvents.push(event)
+            return
+          }
+          begin()
+          write({ type: event.type, key: event.id, value: event.data })
+          commit()
+        })
+
+        // 2. Fetch initial data
+        fetch(config.endpoint).then(async (res) => {
+          const items = await res.json()
+          begin()
+          for (const item of items) {
+            write({ type: 'insert', value: item })
+          }
+          commit()
+
+          // 3. Process buffered events
+          isInitialSyncComplete = true
+          for (const event of bufferedEvents) {
+            begin()
+            write({ type: event.type, key: event.id, value: event.data })
+            commit()
+          }
+
+          // 4. Signal readiness
+          markReady()
+        })
+
+        // 5. Return cleanup function
+        return () => {
+          unsubscribe()
+        }
+      },
+      rowUpdateMode: 'partial',
+    },
+    onInsert: async ({ transaction }) => {
+      await fetch(config.endpoint, {
+        method: 'POST',
+        body: JSON.stringify(transaction.mutations[0].modified),
+      })
+    },
+    onUpdate: async ({ transaction }) => {
+      const mut = transaction.mutations[0]
+      await fetch(`${config.endpoint}/${mut.key}`, {
+        method: 'PATCH',
+        body: JSON.stringify(mut.changes),
+      })
+    },
+    onDelete: async ({ transaction }) => {
+      await fetch(`${config.endpoint}/${transaction.mutations[0].key}`, {
+        method: 'DELETE',
+      })
+    },
+  }
+}
+```
+
+## Core Patterns
+
+### ChangeMessage format
+
+```ts
+// Insert
+write({ type: 'insert', value: item })
+
+// Update (partial — only changed fields)
+write({ type: 'update', key: itemId, value: partialItem })
+
+// Update (full row replacement)
+write({ type: 'update', key: itemId, value: fullItem })
+// Set rowUpdateMode: "full" in sync config
+
+// Delete
+write({ type: 'delete', key: itemId, value: item })
+```
+
+### On-demand sync with loadSubset
+
+```ts
+import { parseLoadSubsetOptions } from "@tanstack/db"
+
+sync: {
+  sync: ({ begin, write, commit, markReady }) => {
+    // Initial sync...
+    markReady()
+    return () => {}
+  },
+  loadSubset: async (options) => {
+    const { filters, sorts, limit, offset } = parseLoadSubsetOptions(options)
+    // filters: [{ field: ['category'], operator: 'eq', value: 'electronics' }]
+    // sorts:   [{ field: ['price'], direction: 'asc', nulls: 'last' }]
+    const params = new URLSearchParams()
+    for (const f of filters) {
+      params.set(f.field.join("."), `${f.operator}:${f.value}`)
+    }
+    const res = await fetch(`/api/items?${params}`)
+    return res.json()
+  },
+}
+```
+
+### Managing optimistic state duration
+
+Mutation handlers must not resolve until server changes have synced back to the collection. Five strategies:
+
+1. **Refetch** (simplest): `await collection.utils.refetch()`
+2. **Transaction ID**: return `{ txid }` and track via sync stream
+3. **ID-based tracking**: await specific record ID appearing in sync stream
+4. **Version/timestamp**: wait until sync stream catches up to mutation time
+5. **Provider method**: `await backend.waitForPendingWrites()`
+
+### Persisted sync metadata
+
+The `metadata` API on the sync config allows adapters to store per-row and per-collection metadata that persists across sync transactions. This is useful for tracking resume tokens, cursors, LSNs, or other adapter-specific state.
+
+The `metadata` object is available as a property on the sync config argument alongside `begin`, `write`, `commit`, etc. It is always provided, but without persistence the metadata is in-memory only and does not survive reloads. With persistence, metadata is durable across sessions.
+
+```ts
+sync: ({ begin, write, commit, markReady, metadata }) => {
+  // Row metadata: store per-row state (e.g. server version, ETag)
+  metadata.row.get(key) // => unknown | undefined
+  metadata.row.set(key, { version: 3, etag: 'abc' })
+  metadata.row.delete(key)
+
+  // Collection metadata: store per-collection state (e.g. resume cursor)
+  metadata.collection.get('cursor') // => unknown | undefined
+  metadata.collection.set('cursor', 'token_abc123')
+  metadata.collection.delete('cursor')
+  metadata.collection.list() // => [{ key: 'cursor', value: 'token_abc123' }]
+  metadata.collection.list('resume') // filter by prefix
+}
+```
+
+Row metadata writes are tied to the current transaction. When a row is deleted via `write({ type: 'delete', ... })`, its row metadata is automatically deleted. When a row is inserted, its metadata is set from `message.metadata` if provided, or deleted otherwise.
+
+Collection metadata writes staged before `truncate()` are preserved and commit atomically with the truncate transaction.
+
+**Typical usage — resume token:**
+
+```ts
+sync: ({ begin, write, commit, markReady, metadata }) => {
+  const lastCursor = metadata.collection.get('cursor') as string | undefined
+
+  const stream = subscribeFromCursor(lastCursor)
+  stream.on('data', (batch) => {
+    begin()
+    for (const item of batch.items) {
+      write({ type: item.type, key: item.id, value: item.data })
+    }
+    metadata.collection.set('cursor', batch.cursor)
+    commit()
+  })
+
+  stream.on('ready', () => markReady())
+  return () => stream.close()
+}
+```
+
+### Expression parsing for predicate push-down
+
+```ts
+import {
+  parseWhereExpression,
+  parseOrderByExpression,
+  extractSimpleComparisons,
+} from '@tanstack/db'
+
+// In loadSubset or queryFn:
+const comparisons = extractSimpleComparisons(options.where)
+// Returns: [{ field: ['name'], operator: 'eq', value: 'John' }]
+
+const orderBy = parseOrderByExpression(options.orderBy)
+// Returns: [{ field: ['created_at'], direction: 'desc', nulls: 'last' }]
+```
+
+## Common Mistakes
+
+### CRITICAL Not calling markReady() in sync implementation
+
+Wrong:
+
+```ts
+sync: ({ begin, write, commit }) => {
+  fetchData().then((items) => {
+    begin()
+    items.forEach((item) => write({ type: 'insert', value: item }))
+    commit()
+    // forgot markReady()!
+  })
+}
+```
+
+Correct:
+
+```ts
+sync: ({ begin, write, commit, markReady }) => {
+  fetchData().then((items) => {
+    begin()
+    items.forEach((item) => write({ type: 'insert', value: item }))
+    commit()
+    markReady()
+  })
+}
+```
+
+`markReady()` transitions the collection to "ready" status. Without it, live queries never resolve and `useLiveSuspenseQuery` hangs forever in Suspense.
+
+Source: docs/guides/collection-options-creator.md
+
+### HIGH Race condition: subscribing after initial fetch
+
+Wrong:
+
+```ts
+sync: ({ begin, write, commit, markReady }) => {
+  fetchAll().then((data) => {
+    writeAll(data)
+    subscribe(onChange) // changes during fetch are LOST
+    markReady()
+  })
+}
+```
+
+Correct:
+
+```ts
+sync: ({ begin, write, commit, markReady }) => {
+  const buffer = []
+  subscribe((event) => {
+    if (!ready) {
+      buffer.push(event)
+      return
+    }
+    begin()
+    write(event)
+    commit()
+  })
+  fetchAll().then((data) => {
+    writeAll(data)
+    ready = true
+    buffer.forEach((e) => {
+      begin()
+      write(e)
+      commit()
+    })
+    markReady()
+  })
+}
+```
+
+Subscribe to real-time events before fetching initial data. Buffer events during the fetch, then replay them after the initial sync completes.
+
+Source: docs/guides/collection-options-creator.md
+
+### HIGH write() called without begin()
+
+Wrong:
+
+```ts
+onMessage((event) => {
+  write({ type: event.type, key: event.id, value: event.data })
+  commit()
+})
+```
+
+Correct:
+
+```ts
+onMessage((event) => {
+  begin()
+  write({ type: event.type, key: event.id, value: event.data })
+  commit()
+})
+```
+
+Sync data must be written within a transaction (`begin` → `write` → `commit`). Calling `write()` without `begin()` throws `NoPendingSyncTransactionWriteError`.
+
+Source: packages/db/src/collection/sync.ts:110
+
+## Tension: Simplicity vs. Correctness in Sync
+
+Getting-started simplicity (localOnly, eager mode) conflicts with production correctness (on-demand sync, race condition prevention, proper markReady handling). Agents optimizing for quick setup tend to skip buffering, markReady, and cleanup functions.
+
+See also: db-core/collection-setup/SKILL.md — for built-in adapter patterns to model after.

--- a/.agents/skills/db-core/live-queries/SKILL.md
+++ b/.agents/skills/db-core/live-queries/SKILL.md
@@ -1,0 +1,493 @@
+---
+name: db-core/live-queries
+description: >
+  Query builder fluent API: from, where, join, leftJoin, rightJoin, innerJoin,
+  fullJoin, select, fn.select, groupBy, having, orderBy, limit, offset, distinct,
+  findOne. Operators: eq, gt, gte, lt, lte, like, ilike, inArray, isNull,
+  isUndefined, and, or, not. Aggregates: count, sum, avg, min, max. String
+  functions: upper, lower, length, concat, coalesce. Math: add. $selected
+  namespace. createLiveQueryCollection. Derived collections. Predicate push-down.
+  Incremental view maintenance via differential dataflow (d2ts). Virtual
+  properties ($synced, $origin, $key, $collectionId). Includes subqueries
+  for hierarchical data. toArray and concat(toArray(...)) scalar includes.
+  queryOnce for one-shot queries. createEffect for reactive side effects
+  (onEnter, onUpdate, onExit, onBatch).
+type: sub-skill
+library: db
+library_version: '0.6.0'
+sources:
+  - 'TanStack/db:docs/guides/live-queries.md'
+  - 'TanStack/db:packages/db/src/query/builder/index.ts'
+  - 'TanStack/db:packages/db/src/query/compiler/index.ts'
+---
+
+# Live Queries
+
+> This skill builds on db-core.
+
+TanStack DB live queries use a SQL-like fluent query builder to create **reactive derived collections** that automatically update when underlying data changes. The query engine compiles queries into incremental view maintenance (IVM) pipelines using differential dataflow (d2ts), so only deltas are recomputed.
+
+All operators, string functions, math functions, and aggregates are incrementally maintained. Prefer them over equivalent JS code.
+
+## Setup
+
+Minimal example using the core API (no framework hooks):
+
+```ts
+import {
+  createCollection,
+  createLiveQueryCollection,
+  liveQueryCollectionOptions,
+  eq,
+} from '@tanstack/db'
+
+// Assume usersCollection is already created via createCollection(...)
+
+// Option 1: createLiveQueryCollection shorthand
+const activeUsers = createLiveQueryCollection((q) =>
+  q
+    .from({ user: usersCollection })
+    .where(({ user }) => eq(user.active, true))
+    .select(({ user }) => ({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+    })),
+)
+
+// Option 2: full options via liveQueryCollectionOptions
+const activeUsers2 = createCollection(
+  liveQueryCollectionOptions({
+    query: (q) =>
+      q
+        .from({ user: usersCollection })
+        .where(({ user }) => eq(user.active, true))
+        .select(({ user }) => ({
+          id: user.id,
+          name: user.name,
+        })),
+    getKey: (user) => user.id,
+  }),
+)
+
+// The result is a live collection -- iterate, subscribe, or use as source
+for (const user of activeUsers) {
+  console.log(user.name)
+}
+```
+
+## Core Patterns
+
+### 1. Filtering with where + operators
+
+Chain `.where()` calls (ANDed together) using expression operators. Use `and()`, `or()`, `not()` for complex logic.
+
+```ts
+import { eq, gt, or, and, not, inArray, like } from '@tanstack/db'
+
+const results = createLiveQueryCollection((q) =>
+  q
+    .from({ user: usersCollection })
+    .where(({ user }) => eq(user.active, true))
+    .where(({ user }) =>
+      and(
+        gt(user.age, 18),
+        or(eq(user.role, 'admin'), eq(user.role, 'moderator')),
+        not(inArray(user.id, bannedIds)),
+      ),
+    ),
+)
+```
+
+Boolean column references work directly:
+
+```ts
+.where(({ user }) => user.active)        // bare boolean ref
+.where(({ user }) => not(user.suspended)) // negated boolean ref
+```
+
+### 2. Joining two collections
+
+Join conditions **must** use `eq()` (equality only -- IVM constraint). Default join type is `left`. Convenience methods: `leftJoin`, `rightJoin`, `innerJoin`, `fullJoin`.
+
+```ts
+import { eq } from '@tanstack/db'
+
+const userPosts = createLiveQueryCollection((q) =>
+  q
+    .from({ user: usersCollection })
+    .innerJoin({ post: postsCollection }, ({ user, post }) =>
+      eq(user.id, post.userId),
+    )
+    .select(({ user, post }) => ({
+      userName: user.name,
+      postTitle: post.title,
+    })),
+)
+```
+
+Multiple joins:
+
+```ts
+q.from({ user: usersCollection })
+  .join({ post: postsCollection }, ({ user, post }) => eq(user.id, post.userId))
+  .join({ comment: commentsCollection }, ({ post, comment }) =>
+    eq(post.id, comment.postId),
+  )
+```
+
+### 3. Aggregation with groupBy + having
+
+Use `groupBy` to group rows, then aggregate in `select`. Filter groups with `having`. The `$selected` namespace lets `having` and `orderBy` reference fields defined in `select`.
+
+```ts
+import { count, sum, gt } from '@tanstack/db'
+
+const topCustomers = createLiveQueryCollection((q) =>
+  q
+    .from({ order: ordersCollection })
+    .groupBy(({ order }) => order.customerId)
+    .select(({ order }) => ({
+      customerId: order.customerId,
+      totalSpent: sum(order.amount),
+      orderCount: count(order.id),
+    }))
+    .having(({ $selected }) => gt($selected.totalSpent, 1000))
+    .orderBy(({ $selected }) => $selected.totalSpent, 'desc')
+    .limit(10),
+)
+```
+
+Without `groupBy`, aggregates in `select` treat the entire collection as one group:
+
+```ts
+const stats = createLiveQueryCollection((q) =>
+  q.from({ user: usersCollection }).select(({ user }) => ({
+    totalUsers: count(user.id),
+    avgAge: avg(user.age),
+  })),
+)
+```
+
+### 4. Standalone derived collection with createLiveQueryCollection
+
+Derived collections are themselves collections. Use one as a source for another query to cache intermediate results:
+
+```ts
+// Base derived collection
+const activeUsers = createLiveQueryCollection((q) =>
+  q.from({ user: usersCollection }).where(({ user }) => eq(user.active, true)),
+)
+
+// Second query uses the derived collection as its source
+const activeUserPosts = createLiveQueryCollection((q) =>
+  q
+    .from({ user: activeUsers })
+    .join({ post: postsCollection }, ({ user, post }) =>
+      eq(user.id, post.userId),
+    )
+    .select(({ user, post }) => ({
+      userName: user.name,
+      postTitle: post.title,
+    })),
+)
+```
+
+Create derived collections once at module scope and reuse them. Do not recreate on every render or navigation.
+
+## Virtual Properties
+
+Live query results include computed, read-only virtual properties on every row:
+
+- `$synced`: `true` when the row is confirmed by sync; `false` when it is still optimistic.
+- `$origin`: `"local"` if the last confirmed change came from this client, otherwise `"remote"`.
+- `$key`: the row key for the result.
+- `$collectionId`: the source collection ID.
+
+These props are added automatically and can be used in `where`, `select`, and `orderBy` clauses. Do not persist them back to storage.
+
+## Includes (Subqueries in Select)
+
+Embed a correlated subquery inside `select()` to produce hierarchical (nested) data. The subquery must contain a `where` with an `eq()` that correlates a parent field with a child field. Three materialization modes are available.
+
+### Collection includes (default)
+
+Return a child `Collection` on each parent row:
+
+```ts
+import { eq, createLiveQueryCollection } from '@tanstack/db'
+
+const projectsWithIssues = createLiveQueryCollection((q) =>
+  q.from({ p: projectsCollection }).select(({ p }) => ({
+    id: p.id,
+    name: p.name,
+    issues: q
+      .from({ i: issuesCollection })
+      .where(({ i }) => eq(i.projectId, p.id))
+      .select(({ i }) => ({
+        id: i.id,
+        title: i.title,
+      })),
+  })),
+)
+
+// Each row's `issues` is a live Collection
+for (const project of projectsWithIssues) {
+  console.log(project.name, project.issues.toArray)
+}
+```
+
+### Array includes with toArray()
+
+Wrap the subquery in `toArray()` to get a plain array of scalar values instead of a Collection:
+
+```ts
+import { eq, toArray, createLiveQueryCollection } from '@tanstack/db'
+
+const messagesWithParts = createLiveQueryCollection((q) =>
+  q.from({ m: messagesCollection }).select(({ m }) => ({
+    id: m.id,
+    contentParts: toArray(
+      q
+        .from({ c: chunksCollection })
+        .where(({ c }) => eq(c.messageId, m.id))
+        .orderBy(({ c }) => c.timestamp)
+        .select(({ c }) => c.text),
+    ),
+  })),
+)
+// row.contentParts is string[]
+```
+
+### Concatenated scalar with concat(toArray())
+
+Wrap `toArray()` in `concat()` to join the scalar results into a single string:
+
+```ts
+import { eq, toArray, concat, createLiveQueryCollection } from '@tanstack/db'
+
+const messagesWithContent = createLiveQueryCollection((q) =>
+  q.from({ m: messagesCollection }).select(({ m }) => ({
+    id: m.id,
+    content: concat(
+      toArray(
+        q
+          .from({ c: chunksCollection })
+          .where(({ c }) => eq(c.messageId, m.id))
+          .orderBy(({ c }) => c.timestamp)
+          .select(({ c }) => c.text),
+      ),
+    ),
+  })),
+)
+// row.content is a single concatenated string
+```
+
+### Includes rules
+
+- The subquery **must** have a `where` clause with an `eq()` correlating a parent alias with a child alias. The library extracts this automatically as the join condition.
+- `toArray()` works with both scalar selects (e.g., `select(({ c }) => c.text)` → `string[]`) and object selects (e.g., `select(({ c }) => ({ id: c.id, title: c.title }))` → `Array<{id, title}>`).
+- `concat(toArray())` requires a **scalar** `select` to concatenate into a string.
+- Collection includes (bare subquery) require an **object** `select`.
+- Includes subqueries are compiled into the same incremental pipeline as the parent query -- they are not separate live queries.
+
+## One-Shot Queries with queryOnce
+
+For non-reactive, one-time snapshots use `queryOnce`. It creates a live query collection, preloads it, extracts the results, and cleans up automatically.
+
+```ts
+import { eq, queryOnce } from '@tanstack/db'
+
+const activeUsers = await queryOnce((q) =>
+  q
+    .from({ user: usersCollection })
+    .where(({ user }) => eq(user.active, true))
+    .select(({ user }) => ({ id: user.id, name: user.name })),
+)
+
+// With findOne — resolves to T | undefined
+const user = await queryOnce((q) =>
+  q
+    .from({ user: usersCollection })
+    .where(({ user }) => eq(user.id, userId))
+    .findOne(),
+)
+```
+
+Use `queryOnce` for scripts, loaders, data export, tests, or AI/LLM context building. For UI bindings and reactive updates, use live queries instead.
+
+## Reactive Effects (createEffect)
+
+Reactive effects respond to query result _changes_ without materializing the full result set. Effects fire callbacks when rows enter, exit, or update within a query result — like a database trigger on an arbitrary live query.
+
+```ts
+import { createEffect, eq } from '@tanstack/db'
+
+const effect = createEffect({
+  query: (q) =>
+    q
+      .from({ msg: messagesCollection })
+      .where(({ msg }) => eq(msg.role, 'user')),
+  skipInitial: true,
+  onEnter: async (event, ctx) => {
+    await processNewMessage(event.value, { signal: ctx.signal })
+  },
+  onExit: (event) => {
+    console.log('Message left result set:', event.key)
+  },
+  onError: (error, event) => {
+    console.error(`Failed to process ${event.key}:`, error)
+  },
+})
+
+// Dispose when no longer needed
+await effect.dispose()
+```
+
+| Use case                        | Approach                                              |
+| ------------------------------- | ----------------------------------------------------- |
+| Display query results in UI     | Live query collection + `useLiveQuery`                |
+| React to changes (side effects) | `createEffect` with `onEnter` / `onUpdate` / `onExit` |
+| Inspect full batch of changes   | `createEffect` with `onBatch`                         |
+
+Key options: `id` (optional), `query`, `skipInitial` (skip existing rows on init), `onEnter`, `onUpdate`, `onExit`, `onBatch`, `onError`, `onSourceError`. The `ctx.signal` aborts when the effect is disposed.
+
+## Common Mistakes
+
+### CRITICAL: Using === instead of eq()
+
+JavaScript `===` in a where callback returns a boolean primitive, not an expression object. Throws `InvalidWhereExpressionError`.
+
+```ts
+// WRONG
+q.from({ user: usersCollection }).where(({ user }) => user.active === true)
+
+// CORRECT
+q.from({ user: usersCollection }).where(({ user }) => eq(user.active, true))
+```
+
+### CRITICAL: Filtering in JS instead of query operators
+
+JS `.filter()` / `.map()` on the result array throws away incremental maintenance -- the JS code re-runs from scratch on every change.
+
+```ts
+// WRONG -- re-runs filter on every change
+const { data } = useLiveQuery((q) => q.from({ todos: todosCollection }))
+const active = data.filter((t) => t.completed === false)
+
+// CORRECT -- incrementally maintained
+const { data } = useLiveQuery((q) =>
+  q
+    .from({ todos: todosCollection })
+    .where(({ todos }) => eq(todos.completed, false)),
+)
+```
+
+### HIGH: Not using the full operator set
+
+The library provides string functions (`upper`, `lower`, `length`, `concat`), math (`add`), utility (`coalesce`), and aggregates (`count`, `sum`, `avg`, `min`, `max`). All are incrementally maintained. Prefer them over JS equivalents.
+
+```ts
+// WRONG
+.fn.select((row) => ({
+  name: row.user.name.toUpperCase(),
+  total: row.order.price + row.order.tax,
+}))
+
+// CORRECT
+.select(({ user, order }) => ({
+  name: upper(user.name),
+  total: add(order.price, order.tax),
+}))
+```
+
+### HIGH: .distinct() without .select()
+
+`distinct()` deduplicates by the selected columns. Without `select()`, throws `DistinctRequiresSelectError`.
+
+```ts
+// WRONG
+q.from({ user: usersCollection }).distinct()
+
+// CORRECT
+q.from({ user: usersCollection })
+  .select(({ user }) => ({ country: user.country }))
+  .distinct()
+```
+
+### HIGH: .having() without .groupBy()
+
+`having` filters aggregated groups. Without `groupBy`, there are no groups. Throws `HavingRequiresGroupByError`.
+
+```ts
+// WRONG
+q.from({ order: ordersCollection }).having(({ order }) =>
+  gt(count(order.id), 5),
+)
+
+// CORRECT
+q.from({ order: ordersCollection })
+  .groupBy(({ order }) => order.customerId)
+  .having(({ order }) => gt(count(order.id), 5))
+```
+
+### HIGH: .limit() / .offset() without .orderBy()
+
+Without deterministic ordering, limit/offset results are non-deterministic and cannot be incrementally maintained. Throws `LimitOffsetRequireOrderByError`.
+
+```ts
+// WRONG
+q.from({ user: usersCollection }).limit(10)
+
+// CORRECT
+q.from({ user: usersCollection })
+  .orderBy(({ user }) => user.name)
+  .limit(10)
+```
+
+### HIGH: Join condition using non-eq() operator
+
+The differential dataflow join operator only supports equality joins. Using `gt()`, `like()`, etc. throws `JoinConditionMustBeEqualityError`.
+
+```ts
+// WRONG
+q.from({ user: usersCollection }).join(
+  { post: postsCollection },
+  ({ user, post }) => gt(user.id, post.userId),
+)
+
+// CORRECT
+q.from({ user: usersCollection }).join(
+  { post: postsCollection },
+  ({ user, post }) => eq(user.id, post.userId),
+)
+```
+
+### MEDIUM: Passing source directly instead of {alias: collection}
+
+`from()` and `join()` require sources wrapped as `{alias: collection}`. Passing the collection directly throws `InvalidSourceTypeError`.
+
+```ts
+// WRONG
+q.from(usersCollection)
+
+// CORRECT
+q.from({ users: usersCollection })
+```
+
+## Tension: Query expressiveness vs. IVM constraints
+
+The query builder looks like SQL but has constraints that SQL does not:
+
+- **Equality joins only** -- `eq()` is the only allowed join condition operator.
+- **orderBy required for limit/offset** -- non-deterministic pagination cannot be incrementally maintained.
+- **distinct requires select** -- deduplication needs an explicit projection.
+- **fn.select() cannot be used with groupBy()** -- the compiler must statically analyze select to discover aggregate functions.
+
+These constraints exist because the underlying d2ts differential dataflow engine requires them for correct incremental view maintenance.
+
+See also: react-db/SKILL.md for React hooks (`useLiveQuery`, `useLiveSuspenseQuery`, `useLiveInfiniteQuery`).
+
+## References
+
+- [Query Operators Reference](./references/operators.md) -- full signatures and examples for all operators, functions, and aggregates.

--- a/.agents/skills/db-core/live-queries/SKILL.md
+++ b/.agents/skills/db-core/live-queries/SKILL.md
@@ -486,7 +486,9 @@ The query builder looks like SQL but has constraints that SQL does not:
 
 These constraints exist because the underlying d2ts differential dataflow engine requires them for correct incremental view maintenance.
 
-See also: react-db/SKILL.md for React hooks (`useLiveQuery`, `useLiveSuspenseQuery`, `useLiveInfiniteQuery`).
+See also: `@tanstack/react-db` for React hooks (`useLiveQuery`,
+`useLiveSuspenseQuery`, `useLiveInfiniteQuery`). No separate local React DB
+skill is installed in this repo.
 
 ## References
 

--- a/.agents/skills/db-core/live-queries/references/operators.md
+++ b/.agents/skills/db-core/live-queries/references/operators.md
@@ -1,0 +1,302 @@
+# Query Operators Reference
+
+All operators are imported from `@tanstack/db` (also re-exported by `@tanstack/react-db` and other framework packages).
+
+```ts
+import {
+  // Comparison
+  eq,
+  gt,
+  gte,
+  lt,
+  lte,
+  like,
+  ilike,
+  inArray,
+  isNull,
+  isUndefined,
+  // Logical
+  and,
+  or,
+  not,
+  // Aggregate
+  count,
+  sum,
+  avg,
+  min,
+  max,
+  // String
+  upper,
+  lower,
+  length,
+  concat,
+  // Math
+  add,
+  // Utility
+  coalesce,
+} from '@tanstack/db'
+```
+
+---
+
+## Comparison Operators
+
+### eq(left, right) -> BasicExpression\<boolean\>
+
+Equality comparison. Works with any type.
+
+```ts
+eq(user.id, 1)
+eq(user.name, 'Alice')
+```
+
+### not(eq(left, right)) — not-equal pattern
+
+There is no `ne` operator. Use `not(eq(...))` for not-equal:
+
+```ts
+not(eq(user.role, 'banned'))
+```
+
+### gt, gte, lt, lte (left, right) -> BasicExpression\<boolean\>
+
+Ordering comparisons. Work with numbers, strings, dates.
+
+```ts
+gt(user.age, 18) // greater than
+gte(user.salary, 50000) // greater than or equal
+lt(user.age, 65) // less than
+lte(user.rating, 5) // less than or equal
+gt(user.createdAt, new Date('2024-01-01'))
+```
+
+### like(left, right) -> BasicExpression\<boolean\>
+
+Case-sensitive string pattern matching. Use `%` as wildcard.
+
+```ts
+like(user.name, 'John%') // starts with John
+like(user.email, '%@corp.com') // ends with @corp.com
+```
+
+### ilike(left, right) -> BasicExpression\<boolean\>
+
+Case-insensitive string pattern matching.
+
+```ts
+ilike(user.email, '%@gmail.com')
+```
+
+### inArray(value, array) -> BasicExpression\<boolean\>
+
+Check if value is contained in an array.
+
+```ts
+inArray(user.id, [1, 2, 3])
+inArray(user.role, ['admin', 'moderator'])
+```
+
+### isNull(value) -> BasicExpression\<boolean\>
+
+Check if value is explicitly `null`.
+
+```ts
+isNull(user.bio)
+```
+
+### isUndefined(value) -> BasicExpression\<boolean\>
+
+Check if value is `undefined` (absent). Especially useful after left joins where unmatched rows produce `undefined`.
+
+```ts
+isUndefined(profile) // no matching profile in left join
+```
+
+---
+
+## Logical Operators
+
+### and(...conditions) -> BasicExpression\<boolean\>
+
+Combine two or more conditions with AND logic.
+
+```ts
+and(eq(user.active, true), gt(user.age, 18))
+and(eq(user.active, true), gt(user.age, 18), eq(user.role, 'user'))
+```
+
+### or(...conditions) -> BasicExpression\<boolean\>
+
+Combine two or more conditions with OR logic.
+
+```ts
+or(eq(user.role, 'admin'), eq(user.role, 'moderator'))
+```
+
+### not(condition) -> BasicExpression\<boolean\>
+
+Negate a condition.
+
+```ts
+not(eq(user.active, false))
+not(inArray(user.id, bannedIds))
+```
+
+---
+
+## Aggregate Functions
+
+Used inside `.select()` with `.groupBy()`, or without `groupBy` to aggregate the entire collection as one group.
+
+### count(value) -> Aggregate\<number\>
+
+Count non-null values in a group.
+
+```ts
+count(user.id)
+```
+
+### sum(value), avg(value) -> Aggregate\<number | null | undefined\>
+
+Sum or average of numeric values.
+
+```ts
+sum(order.amount)
+avg(user.salary)
+```
+
+### min(value), max(value) -> Aggregate\<T\>
+
+Minimum/maximum value (numbers, strings, dates).
+
+```ts
+min(order.amount)
+max(user.createdAt)
+```
+
+---
+
+## String Functions
+
+### upper(value), lower(value) -> BasicExpression\<string\>
+
+Convert string case.
+
+```ts
+upper(user.name) // 'ALICE'
+lower(user.email) // 'alice@example.com'
+```
+
+### length(value) -> BasicExpression\<number\>
+
+Get string or array length.
+
+```ts
+length(user.name) // string length
+length(user.tags) // array length
+```
+
+### concat(...values) -> BasicExpression\<string\>
+
+Concatenate any number of values into a string.
+
+```ts
+concat(user.firstName, ' ', user.lastName)
+```
+
+---
+
+## Math Functions
+
+### add(left, right) -> BasicExpression\<number\>
+
+Add two numeric values.
+
+```ts
+add(order.price, order.tax)
+add(user.salary, coalesce(user.bonus, 0))
+```
+
+---
+
+## Utility Functions
+
+### coalesce(...values) -> BasicExpression\<any\>
+
+Return the first non-null, non-undefined value.
+
+```ts
+coalesce(user.displayName, user.name, 'Unknown')
+coalesce(user.bonus, 0)
+```
+
+---
+
+## $selected Namespace
+
+When a query has a `.select()` clause, the `$selected` namespace becomes available in `.orderBy()` and `.having()` callbacks. It provides access to the computed/aggregated fields defined in `select`.
+
+```ts
+q.from({ order: ordersCollection })
+  .groupBy(({ order }) => order.customerId)
+  .select(({ order }) => ({
+    customerId: order.customerId,
+    totalSpent: sum(order.amount),
+    orderCount: count(order.id),
+  }))
+  .having(({ $selected }) => gt($selected.totalSpent, 1000))
+  .orderBy(({ $selected }) => $selected.totalSpent, 'desc')
+```
+
+`$selected` is only available when `.select()` (or `.fn.select()`) has been called on the query.
+
+---
+
+## Functional Variants (fn.select, fn.where, fn.having)
+
+Escape hatches for logic that cannot be expressed with declarative operators. These execute arbitrary JS on each row but **cannot be optimized** by the query compiler (no predicate push-down, no index use).
+
+### fn.select(callback)
+
+```ts
+q.from({ user: usersCollection }).fn.select((row) => ({
+  id: row.user.id,
+  domain: row.user.email.split('@')[1],
+  tier: row.user.salary > 100000 ? 'senior' : 'junior',
+}))
+```
+
+**Limitation**: `fn.select()` cannot be used with `groupBy()`. The compiler must statically analyze select to discover aggregate functions.
+
+### fn.where(callback)
+
+```ts
+q.from({ user: usersCollection }).fn.where(
+  (row) => row.user.active && row.user.email.endsWith('@company.com'),
+)
+```
+
+### fn.having(callback)
+
+Receives `$selected` when a `select()` clause exists.
+
+```ts
+q.from({ order: ordersCollection })
+  .groupBy(({ order }) => order.customerId)
+  .select(({ order }) => ({
+    customerId: order.customerId,
+    totalSpent: sum(order.amount),
+    orderCount: count(order.id),
+  }))
+  .fn.having(
+    ({ $selected }) => $selected.totalSpent > 1000 && $selected.orderCount >= 3,
+  )
+```
+
+### When to use functional variants
+
+- String manipulation not covered by `upper`/`lower`/`concat`/`like` (e.g., `split`, `slice`, regex)
+- Complex conditional logic (ternaries, multi-branch)
+- External function calls or lookups
+
+Prefer declarative operators whenever possible for incremental maintenance.

--- a/.agents/skills/db-core/mutations-optimistic/SKILL.md
+++ b/.agents/skills/db-core/mutations-optimistic/SKILL.md
@@ -1,0 +1,375 @@
+---
+name: db-core/mutations-optimistic
+description: >
+  collection.insert, collection.update (Immer-style draft proxy),
+  collection.delete. createOptimisticAction (onMutate + mutationFn).
+  createPacedMutations with debounceStrategy, throttleStrategy, queueStrategy.
+  createTransaction, getActiveTransaction, ambient transaction context.
+  Transaction lifecycle (pending/persisting/completed/failed). Mutation merging.
+  onInsert/onUpdate/onDelete handlers. PendingMutation type. Transaction.isPersisted.
+type: sub-skill
+library: db
+library_version: '0.6.0'
+sources:
+  - 'TanStack/db:docs/guides/mutations.md'
+  - 'TanStack/db:packages/db/src/transactions.ts'
+  - 'TanStack/db:packages/db/src/optimistic-action.ts'
+  - 'TanStack/db:packages/db/src/paced-mutations.ts'
+---
+
+# Mutations & Optimistic State
+
+> **Depends on:** `db-core/collection-setup` -- you need a configured collection
+> (with `getKey`, sync adapter, and optionally `onInsert`/`onUpdate`/`onDelete`
+> handlers) before you can mutate.
+
+TanStack DB mutations follow a unidirectional loop:
+**optimistic mutation -> handler persists to backend -> sync back -> confirmed state**.
+Optimistic state is applied in the current tick and dropped when the handler resolves.
+
+---
+
+## Setup -- Collection Write Operations
+
+### insert
+
+```ts
+// Single item
+todoCollection.insert({
+  id: crypto.randomUUID(),
+  text: 'Buy groceries',
+  completed: false,
+})
+
+// Multiple items
+todoCollection.insert([
+  { id: crypto.randomUUID(), text: 'Buy groceries', completed: false },
+  { id: crypto.randomUUID(), text: 'Walk dog', completed: false },
+])
+
+// With metadata / non-optimistic
+todoCollection.insert(item, { metadata: { source: 'import' } })
+todoCollection.insert(item, { optimistic: false })
+```
+
+### update (Immer-style draft proxy)
+
+```ts
+// Single item -- mutate the draft, do NOT reassign it
+todoCollection.update(todo.id, (draft) => {
+  draft.completed = true
+  draft.completedAt = new Date()
+})
+
+// Multiple items
+todoCollection.update([id1, id2], (drafts) => {
+  drafts.forEach((d) => {
+    d.completed = true
+  })
+})
+
+// With metadata
+todoCollection.update(
+  todo.id,
+  { metadata: { reason: 'user-edit' } },
+  (draft) => {
+    draft.text = 'Updated'
+  },
+)
+```
+
+### delete
+
+```ts
+todoCollection.delete(todo.id)
+todoCollection.delete([id1, id2])
+todoCollection.delete(todo.id, { metadata: { reason: 'completed' } })
+```
+
+All three return a `Transaction` object. Use `tx.isPersisted.promise` to await
+persistence or catch rollback errors.
+
+---
+
+## Core Patterns
+
+### 1. createOptimisticAction -- intent-based mutations
+
+Use when the optimistic change is a _guess_ at how the server will transform
+the data, or when you need to mutate multiple collections atomically.
+
+```ts
+import { createOptimisticAction } from '@tanstack/db'
+
+const likePost = createOptimisticAction<string>({
+  // MUST be synchronous -- applied in the current tick
+  onMutate: (postId) => {
+    postCollection.update(postId, (draft) => {
+      draft.likeCount += 1
+      draft.likedByMe = true
+    })
+  },
+  mutationFn: async (postId, { transaction }) => {
+    await api.posts.like(postId)
+    // IMPORTANT: wait for server state to sync back before returning
+    await postCollection.utils.refetch()
+  },
+})
+
+// Returns a Transaction
+const tx = likePost(postId)
+await tx.isPersisted.promise
+```
+
+Multi-collection example:
+
+```ts
+const createProject = createOptimisticAction<{ name: string; ownerId: string }>(
+  {
+    onMutate: ({ name, ownerId }) => {
+      projectCollection.insert({ id: crypto.randomUUID(), name, ownerId })
+      userCollection.update(ownerId, (d) => {
+        d.projectCount += 1
+      })
+    },
+    mutationFn: async ({ name, ownerId }) => {
+      await api.projects.create({ name, ownerId })
+      await Promise.all([
+        projectCollection.utils.refetch(),
+        userCollection.utils.refetch(),
+      ])
+    },
+  },
+)
+```
+
+### 2. createPacedMutations -- auto-save with debounce / throttle / queue
+
+```ts
+import { createPacedMutations, debounceStrategy } from '@tanstack/db'
+
+const autoSaveNote = createPacedMutations<string>({
+  onMutate: (text) => {
+    noteCollection.update(noteId, (draft) => {
+      draft.body = text
+    })
+  },
+  mutationFn: async ({ transaction }) => {
+    const mutation = transaction.mutations[0]
+    await api.notes.update(mutation.key, mutation.changes)
+    await noteCollection.utils.refetch()
+  },
+  strategy: debounceStrategy({ wait: 500 }),
+})
+
+// Each call resets the debounce timer; mutations merge into one transaction
+autoSaveNote('Hello')
+autoSaveNote('Hello, world') // only this version persists
+```
+
+Other strategies:
+
+```ts
+import { throttleStrategy, queueStrategy } from '@tanstack/db'
+
+// Evenly spaced (sliders, scroll)
+throttleStrategy({ wait: 200, leading: true, trailing: true })
+
+// Sequential FIFO -- every mutation persisted in order
+queueStrategy({ wait: 0, maxSize: 100 })
+```
+
+### 3. createTransaction -- manual batching
+
+```ts
+import { createTransaction } from '@tanstack/db'
+
+const tx = createTransaction({
+  autoCommit: false, // wait for explicit commit()
+  mutationFn: async ({ transaction }) => {
+    await api.batchUpdate(transaction.mutations)
+  },
+})
+
+tx.mutate(() => {
+  todoCollection.update(id1, (d) => {
+    d.status = 'reviewed'
+  })
+  todoCollection.update(id2, (d) => {
+    d.status = 'reviewed'
+  })
+})
+
+// User reviews... then commits or rolls back
+await tx.commit()
+// OR: tx.rollback()
+```
+
+Inside `tx.mutate(() => { ... })`, the transaction is pushed onto an ambient
+stack. Any `collection.insert/update/delete` call joins the ambient transaction
+automatically via `getActiveTransaction()`.
+
+### 4. Mutation handler with refetch (QueryCollection pattern)
+
+```ts
+const todoCollection = createCollection(
+  queryCollectionOptions({
+    queryKey: ['todos'],
+    queryFn: () => api.todos.getAll(),
+    getKey: (t) => t.id,
+    onInsert: async ({ transaction }) => {
+      await Promise.all(
+        transaction.mutations.map((m) => api.todos.create(m.modified)),
+      )
+      // IMPORTANT: handler must not resolve until server state is synced back
+      // QueryCollection auto-refetches after handler completes
+    },
+    onUpdate: async ({ transaction }) => {
+      await Promise.all(
+        transaction.mutations.map((m) =>
+          api.todos.update(m.original.id, m.changes),
+        ),
+      )
+    },
+    onDelete: async ({ transaction }) => {
+      await Promise.all(
+        transaction.mutations.map((m) => api.todos.delete(m.original.id)),
+      )
+    },
+  }),
+)
+```
+
+For ElectricCollection, return `{ txid }` instead of refetching:
+
+```ts
+onUpdate: async ({ transaction }) => {
+  const txids = await Promise.all(
+    transaction.mutations.map(async (m) => {
+      const res = await api.todos.update(m.original.id, m.changes)
+      return res.txid
+    }),
+  )
+  return { txid: txids }
+}
+```
+
+---
+
+## Common Mistakes
+
+### CRITICAL: Passing an object to update() instead of a draft callback
+
+```ts
+// WRONG -- silently fails or throws
+collection.update(id, { ...item, title: 'new' })
+
+// CORRECT -- mutate the draft proxy
+collection.update(id, (draft) => {
+  draft.title = 'new'
+})
+```
+
+### CRITICAL: Hallucinating mutation API signatures
+
+The most common AI-generated errors:
+
+- Inventing handler signatures (e.g. `onMutate` on a collection config)
+- Confusing `createOptimisticAction` with `createTransaction`
+- Wrong PendingMutation property names (`mutation.data` does not exist --
+  use `mutation.modified`, `mutation.changes`, `mutation.original`)
+- Missing the ambient transaction pattern
+
+Always reference the exact types in `references/transaction-api.md`.
+
+### CRITICAL: onMutate returning a Promise
+
+`onMutate` in `createOptimisticAction` **must be synchronous**. Optimistic state
+is applied in the current tick. Returning a Promise throws
+`OnMutateMustBeSynchronousError`.
+
+```ts
+// WRONG
+createOptimisticAction({
+  onMutate: async (text) => {
+    collection.insert({ id: await generateId(), text })
+  },
+  ...
+})
+
+// CORRECT
+createOptimisticAction({
+  onMutate: (text) => {
+    collection.insert({ id: crypto.randomUUID(), text })
+  },
+  ...
+})
+```
+
+### CRITICAL: Mutations without handler or ambient transaction
+
+Collection mutations require either:
+
+1. An `onInsert`/`onUpdate`/`onDelete` handler on the collection, OR
+2. An ambient transaction from `createTransaction`/`createOptimisticAction`
+
+Without either, throws `MissingInsertHandlerError` (or the Update/Delete variant).
+
+### HIGH: Calling .mutate() after transaction is no longer pending
+
+Transactions only accept new mutations while in `pending` state. Calling
+`mutate()` after `commit()` or `rollback()` throws
+`TransactionNotPendingMutateError`. Create a new transaction instead.
+
+### HIGH: Changing primary key via update
+
+The update proxy detects key changes and throws `KeyUpdateNotAllowedError`.
+Primary keys are immutable once set. If you need a different key, delete and
+re-insert.
+
+### HIGH: Inserting item with duplicate key
+
+If an item with the same key already exists (synced or optimistic), throws
+`DuplicateKeyError`. Always generate a unique key (e.g. `crypto.randomUUID()`)
+or check before inserting.
+
+### HIGH: Not awaiting refetch after mutation in query collection handler
+
+The optimistic state is held only until the handler resolves. If the handler
+returns before server state has synced back, optimistic state is dropped and
+users see a flash of missing data.
+
+```ts
+// WRONG -- optimistic state dropped before new server state arrives
+onInsert: async ({ transaction }) => {
+  await api.createTodo(transaction.mutations[0].modified)
+  // missing: await collection.utils.refetch()
+}
+
+// CORRECT
+onInsert: async ({ transaction }) => {
+  await api.createTodo(transaction.mutations[0].modified)
+  await collection.utils.refetch()
+}
+```
+
+---
+
+## Tension: Optimistic Speed vs. Data Consistency
+
+Instant optimistic updates create a window where client state diverges from
+server state. If the handler fails, the rollback removes the optimistic state --
+which can discard user work the user thought was saved. Consider:
+
+- Showing pending/saving indicators so users know state is unconfirmed
+- Using `{ optimistic: false }` for destructive operations
+- Designing idempotent server endpoints so retries are safe
+- Handling `tx.isPersisted.promise` rejection to surface errors to the user
+
+---
+
+## References
+
+- [Transaction API Reference](references/transaction-api.md) -- createTransaction config,
+  Transaction object, PendingMutation type, mutation merging rules, strategy types
+- [TanStack DB Mutations Guide](https://tanstack.com/db/latest/docs/guides/mutations)

--- a/.agents/skills/db-core/mutations-optimistic/references/transaction-api.md
+++ b/.agents/skills/db-core/mutations-optimistic/references/transaction-api.md
@@ -1,0 +1,207 @@
+# Transaction API Reference
+
+## createTransaction
+
+```ts
+import { createTransaction } from "@tanstack/db"
+
+const tx = createTransaction<T>({
+  id?: string,                        // defaults to crypto.randomUUID()
+  autoCommit?: boolean,               // default true -- commit after mutate()
+  mutationFn: MutationFn<T>,          // (params: { transaction }) => Promise<any>
+  metadata?: Record<string, unknown>, // custom data attached to the transaction
+})
+```
+
+## Transaction Object
+
+```ts
+interface Transaction<T> {
+  id: string
+  state: 'pending' | 'persisting' | 'completed' | 'failed'
+  mutations: Array<PendingMutation<T>>
+  autoCommit: boolean
+  createdAt: Date
+  sequenceNumber: number
+  metadata: Record<string, unknown>
+  error?: { message: string; error: Error }
+
+  // Deferred promise -- resolves when mutationFn completes, rejects on failure
+  isPersisted: {
+    promise: Promise<Transaction<T>>
+    resolve: (value: Transaction<T>) => void
+    reject: (reason?: any) => void
+  }
+
+  // Execute collection operations inside the ambient transaction context
+  mutate(callback: () => void): Transaction<T>
+
+  // Commit -- calls mutationFn, transitions to persisting -> completed|failed
+  commit(): Promise<Transaction<T>>
+
+  // Rollback -- transitions to failed, also rolls back conflicting transactions
+  rollback(config?: { isSecondaryRollback?: boolean }): Transaction<T>
+}
+```
+
+**Lifecycle:** `pending` -> `persisting` -> `completed` | `failed`
+
+- `mutate()` only allowed in `pending` state (throws `TransactionNotPendingMutateError`)
+- `commit()` only allowed in `pending` state (throws `TransactionNotPendingCommitError`)
+- `rollback()` allowed in `pending` or `persisting` (throws `TransactionAlreadyCompletedRollbackError` if completed)
+- Failed `mutationFn` automatically triggers `rollback()`
+- Rollback cascades to other pending transactions sharing the same item keys
+
+## PendingMutation Type
+
+```ts
+interface PendingMutation<T, TOperation = 'insert' | 'update' | 'delete'> {
+  mutationId: string // unique id for this mutation
+  original: TOperation extends 'insert' ? {} : T // state before mutation
+  modified: T // state after mutation
+  changes: Partial<T> // only the changed fields
+  key: any // collection-local key
+  globalKey: string // globally unique key (collectionId + key)
+  type: TOperation // "insert" | "update" | "delete"
+  metadata: unknown // user-provided metadata
+  syncMetadata: Record<string, unknown> // adapter-specific metadata
+  optimistic: boolean // whether applied optimistically (default true)
+  createdAt: Date
+  updatedAt: Date
+  collection: Collection // reference to the source collection
+}
+```
+
+## Mutation Merging Rules
+
+When multiple mutations target the same item (same `globalKey`) within a
+transaction, they merge:
+
+| Existing | Incoming | Result    | Notes                              |
+| -------- | -------- | --------- | ---------------------------------- |
+| insert   | update   | insert    | Merge changes, keep empty original |
+| insert   | delete   | _removed_ | Both mutations cancel out          |
+| update   | update   | update    | Union changes, keep first original |
+| update   | delete   | delete    | Delete dominates                   |
+| delete   | delete   | delete    | Replace with latest                |
+| insert   | insert   | insert    | Replace with latest                |
+
+`(delete, update)` and `(delete, insert)` cannot occur -- the collection
+prevents operations on deleted items within the same transaction.
+
+## getActiveTransaction / Ambient Transaction Context
+
+```ts
+import { getActiveTransaction } from '@tanstack/db'
+
+const tx = getActiveTransaction() // Transaction | undefined
+```
+
+Inside `tx.mutate(() => { ... })`, the transaction is pushed onto an internal
+stack. Any `collection.insert/update/delete` call automatically joins the
+topmost ambient transaction. This is how `createOptimisticAction` and
+`createPacedMutations` wire collection operations into their transactions.
+
+## createOptimisticAction
+
+```ts
+import { createOptimisticAction } from "@tanstack/db"
+
+const action = createOptimisticAction<TVariables>({
+  // Synchronous -- apply optimistic state immediately (MUST NOT return a Promise)
+  onMutate: (variables: TVariables) => void,
+
+  // Async -- persist to backend, wait for sync back
+  mutationFn: (variables: TVariables, params: { transaction }) => Promise<any>,
+
+  // Optional: same as createTransaction config
+  id?: string,
+  autoCommit?: boolean,    // always true (commit happens after mutate)
+  metadata?: Record<string, unknown>,
+})
+
+// Returns a function: (variables: TVariables) => Transaction
+const tx = action(variables)
+await tx.isPersisted.promise
+```
+
+## createPacedMutations
+
+```ts
+import { createPacedMutations } from "@tanstack/db"
+
+const mutate = createPacedMutations<TVariables>({
+  onMutate: (variables: TVariables) => void,   // synchronous optimistic update
+  mutationFn: MutationFn,                       // persists merged transaction
+  strategy: Strategy,                            // timing control
+  metadata?: Record<string, unknown>,
+})
+
+// Returns a function: (variables: TVariables) => Transaction
+const tx = mutate(variables)
+```
+
+Rapid calls merge into the active transaction (via `applyMutations`) until the
+strategy fires the commit. A new transaction is created for subsequent calls.
+
+## Strategy Types
+
+### debounceStrategy
+
+```ts
+import { debounceStrategy } from "@tanstack/db"
+
+debounceStrategy({
+  wait: number,           // ms to wait after last call before committing
+  leading?: boolean,      // execute on the leading edge (default false)
+  trailing?: boolean,     // execute on the trailing edge (default true)
+})
+```
+
+### throttleStrategy
+
+```ts
+import { throttleStrategy } from "@tanstack/db"
+
+throttleStrategy({
+  wait: number,           // minimum ms between commits
+  leading?: boolean,      // execute on the leading edge
+  trailing?: boolean,     // execute on the trailing edge
+})
+```
+
+### queueStrategy
+
+```ts
+import { queueStrategy } from "@tanstack/db"
+
+queueStrategy({
+  wait?: number,                      // ms between processing items (default 0)
+  maxSize?: number,                   // drop items if queue exceeds this
+  addItemsTo?: "front" | "back",     // default "back" (FIFO)
+  getItemsFrom?: "front" | "back",   // default "front" (FIFO)
+})
+```
+
+Queue creates a **separate transaction per call** (unlike debounce/throttle
+which merge). Each transaction commits and awaits `isPersisted` before the next
+starts. Failed transactions do not block subsequent ones.
+
+## Transaction.isPersisted.promise
+
+```ts
+const tx = collection.insert({ id: '1', text: 'Hello' })
+
+try {
+  await tx.isPersisted.promise // resolves with the Transaction on success
+  console.log(tx.state) // "completed"
+} catch (error) {
+  console.log(tx.state) // "failed"
+  // optimistic state has been rolled back
+}
+```
+
+The promise is a `Deferred` -- it is created at transaction construction time
+and settled when `commit()` completes or `rollback()` is called. For
+`autoCommit: true` transactions, the promise settles shortly after `mutate()`
+returns (the commit runs asynchronously).

--- a/.agents/skills/db-core/persistence/SKILL.md
+++ b/.agents/skills/db-core/persistence/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: db-core/persistence
+description: >
+  SQLite-backed persistence for TanStack DB collections. persistedCollectionOptions
+  wraps any adapter (Electric, Query, PowerSync, or local-only) with durable local
+  storage. Platform adapters: browser (WA-SQLite OPFS), React Native (op-sqlite),
+  Expo (expo-sqlite), Electron (IPC), Node (better-sqlite3), Capacitor, Tauri,
+  Cloudflare Durable Objects. Multi-tab/multi-process coordination via
+  BrowserCollectionCoordinator / ElectronCollectionCoordinator /
+  SingleProcessCoordinator. schemaVersion for migration resets. Local-only mode
+  for offline-first without a server.
+type: sub-skill
+library: db
+library_version: '0.6.0'
+sources:
+  - 'TanStack/db:packages/db-sqlite-persistence-core/src/persisted.ts'
+  - 'TanStack/db:packages/browser-db-sqlite-persistence/src/index.ts'
+  - 'TanStack/db:packages/react-native-db-sqlite-persistence/src/index.ts'
+  - 'TanStack/db:packages/expo-db-sqlite-persistence/src/index.ts'
+  - 'TanStack/db:packages/electron-db-sqlite-persistence/src/index.ts'
+  - 'TanStack/db:packages/node-db-sqlite-persistence/src/index.ts'
+  - 'TanStack/db:examples/react/offline-transactions/src/db/persisted-todos.ts'
+  - 'TanStack/db:examples/react-native/shopping-list/src/db/collections.ts'
+---
+
+This skill builds on db-core and db-core/collection-setup. Read those first.
+
+# SQLite Persistence
+
+TanStack DB persistence adds a durable SQLite-backed layer to any collection. Data survives page reloads, app restarts, and offline periods. The server remains authoritative for synced collections -- persistence provides a local cache that hydrates instantly.
+
+## Choosing a Platform Package
+
+| Platform       | Package                                                      | Create function                              |
+| -------------- | ------------------------------------------------------------ | -------------------------------------------- |
+| Browser (OPFS) | `@tanstack/browser-db-sqlite-persistence`                    | `createBrowserWASQLitePersistence`           |
+| React Native   | `@tanstack/react-native-db-sqlite-persistence`               | `createReactNativeSQLitePersistence`         |
+| Expo           | `@tanstack/expo-db-sqlite-persistence`                       | `createExpoSQLitePersistence`                |
+| Electron       | `@tanstack/electron-db-sqlite-persistence`                   | `createElectronSQLitePersistence` (renderer) |
+| Node.js        | `@tanstack/node-db-sqlite-persistence`                       | `createNodeSQLitePersistence`                |
+| Capacitor      | `@tanstack/capacitor-db-sqlite-persistence`                  | `createCapacitorSQLitePersistence`           |
+| Tauri          | `@tanstack/tauri-db-sqlite-persistence`                      | `createTauriSQLitePersistence`               |
+| Cloudflare DO  | `@tanstack/cloudflare-durable-objects-db-sqlite-persistence` | `createCloudflareDOSQLitePersistence`        |
+
+All platform packages re-export `persistedCollectionOptions` from the core.
+
+## Local-Only Persistence (No Server)
+
+For purely local data with no sync backend:
+
+```ts
+import { createCollection } from '@tanstack/react-db'
+import {
+  BrowserCollectionCoordinator,
+  createBrowserWASQLitePersistence,
+  openBrowserWASQLiteOPFSDatabase,
+  persistedCollectionOptions,
+} from '@tanstack/browser-db-sqlite-persistence'
+
+const database = await openBrowserWASQLiteOPFSDatabase({
+  databaseName: 'my-app.sqlite',
+})
+
+const coordinator = new BrowserCollectionCoordinator({
+  dbName: 'my-app',
+})
+
+const persistence = createBrowserWASQLitePersistence({
+  database,
+  coordinator,
+})
+
+const draftsCollection = createCollection(
+  persistedCollectionOptions<Draft, string>({
+    id: 'drafts',
+    getKey: (d) => d.id,
+    persistence,
+    schemaVersion: 1,
+  }),
+)
+```
+
+Local-only collections provide `collection.utils.acceptMutations()` for applying mutations directly.
+
+## Synced Persistence (Wrapping an Adapter)
+
+Spread an existing adapter's options into `persistedCollectionOptions` to add persistence on top of sync:
+
+```ts
+import { createCollection } from '@tanstack/react-db'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
+import {
+  createReactNativeSQLitePersistence,
+  persistedCollectionOptions,
+} from '@tanstack/react-native-db-sqlite-persistence'
+
+const persistence = createReactNativeSQLitePersistence({ database })
+
+const todosCollection = createCollection(
+  persistedCollectionOptions({
+    ...electricCollectionOptions({
+      id: 'todos',
+      shapeOptions: { url: '/api/electric/todos' },
+      getKey: (item) => item.id,
+    }),
+    persistence,
+    schemaVersion: 1,
+  }),
+)
+```
+
+This works with any adapter: `electricCollectionOptions`, `queryCollectionOptions`, `powerSyncCollectionOptions`, etc. The `persistedCollectionOptions` wrapper intercepts the sync layer to persist data as it flows through.
+
+## Multi-Tab / Multi-Process Coordination
+
+Coordinators handle leader election and cross-instance communication so only one tab/process owns the database writer.
+
+| Platform                              | Coordinator                     | Mechanism                                      |
+| ------------------------------------- | ------------------------------- | ---------------------------------------------- |
+| Browser                               | `BrowserCollectionCoordinator`  | BroadcastChannel + Web Locks                   |
+| Electron                              | `ElectronCollectionCoordinator` | IPC (main holds DB, renderer accesses via RPC) |
+| Single-process (RN, Expo, Node, etc.) | `SingleProcessCoordinator`      | No-op (always leader)                          |
+
+Browser example:
+
+```ts
+import { BrowserCollectionCoordinator } from '@tanstack/browser-db-sqlite-persistence'
+
+const coordinator = new BrowserCollectionCoordinator({
+  dbName: 'my-app',
+})
+
+// Pass to persistence
+const persistence = createBrowserWASQLitePersistence({ database, coordinator })
+
+// Cleanup on shutdown
+coordinator.dispose()
+```
+
+Electron requires setup in both processes:
+
+```ts
+// Main process
+import { exposeElectronSQLitePersistence } from '@tanstack/electron-db-sqlite-persistence'
+exposeElectronSQLitePersistence({ persistence, ipcMain })
+
+// Renderer process
+import {
+  createElectronSQLitePersistence,
+  ElectronCollectionCoordinator,
+} from '@tanstack/electron-db-sqlite-persistence'
+
+const coordinator = new ElectronCollectionCoordinator({ dbName: 'my-app' })
+const persistence = createElectronSQLitePersistence({
+  ipcRenderer: window.electron.ipcRenderer,
+  coordinator,
+})
+```
+
+## Schema Versioning
+
+`schemaVersion` tracks the shape of persisted data. When the stored version doesn't match the code, the collection resets (drops and reloads from server for synced collections, or throws for local-only).
+
+```ts
+persistedCollectionOptions({
+  // ...
+  schemaVersion: 2, // bump when you change the data shape
+})
+```
+
+There is no custom migration function -- a version mismatch triggers a full reset. For synced collections this is safe because the server re-supplies the data.
+
+## Key Options
+
+| Option          | Type                             | Description                                              |
+| --------------- | -------------------------------- | -------------------------------------------------------- |
+| `persistence`   | `PersistedCollectionPersistence` | Platform adapter + coordinator                           |
+| `schemaVersion` | `number`                         | Data version (default 1). Bump on schema changes         |
+| `id`            | `string`                         | Required for local-only. Collection identifier in SQLite |
+
+## Common Mistakes
+
+### CRITICAL Using local-only persistence without an `id`
+
+Wrong:
+
+```ts
+persistedCollectionOptions({
+  getKey: (d) => d.id,
+  persistence,
+  // missing id — generates random UUID each session, data won't persist across reloads
+})
+```
+
+Correct:
+
+```ts
+persistedCollectionOptions({
+  id: 'drafts',
+  getKey: (d) => d.id,
+  persistence,
+})
+```
+
+Without an explicit `id`, the code generates a random UUID each session, so persisted data is silently abandoned on every reload. Local-only persisted collections must always provide an `id`. Synced collections derive it from the adapter config.
+
+### HIGH Forgetting the coordinator in multi-tab apps
+
+Wrong:
+
+```ts
+const persistence = createBrowserWASQLitePersistence({ database })
+// No coordinator — concurrent tabs corrupt the database
+```
+
+Correct:
+
+```ts
+const coordinator = new BrowserCollectionCoordinator({ dbName: 'my-app' })
+const persistence = createBrowserWASQLitePersistence({ database, coordinator })
+```
+
+Without a coordinator, multiple browser tabs write to SQLite concurrently, causing data corruption. Always use `BrowserCollectionCoordinator` in browser environments.
+
+### HIGH Not bumping schemaVersion after changing data shape
+
+If you add, remove, or rename fields in your collection type but keep the same `schemaVersion`, the persisted SQLite data will have the old shape. For synced collections, bump the version to trigger a reset and re-sync.
+
+### MEDIUM Not disposing the coordinator on cleanup
+
+```ts
+// On app shutdown or hot module reload
+coordinator.dispose()
+await database.close?.()
+```
+
+Failing to dispose leaks BroadcastChannel subscriptions and Web Lock handles.
+
+See also: db-core/collection-setup/SKILL.md — for adapter selection and collection configuration.
+
+See also: offline/SKILL.md — for offline transaction queueing (complements persistence).

--- a/.agents/skills/devtools-vite-plugin/SKILL.md
+++ b/.agents/skills/devtools-vite-plugin/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: devtools-vite-plugin
+description: >
+  Configure @tanstack/devtools-vite for source inspection (data-tsd-source,
+  inspectHotkey, ignore patterns), console piping (client-to-server,
+  server-to-client, levels), enhanced logging, server event bus (port, host,
+  HTTPS), production stripping (removeDevtoolsOnBuild), editor integration
+  (launch-editor, custom editor.open). Must be FIRST plugin in Vite config.
+  Vite ^6 || ^7 only.
+type: core
+library: tanstack-devtools
+library_version: '0.10.12'
+sources:
+  - 'TanStack/devtools:docs/vite-plugin.md'
+  - 'TanStack/devtools:docs/source-inspector.md'
+  - 'TanStack/devtools:packages/devtools-vite/src/plugin.ts'
+---
+
+Configure @tanstack/devtools-vite -- the Vite plugin that enhances TanStack Devtools with source inspection, console piping, enhanced logging, a server event bus, production stripping, editor integration, and a plugin marketplace. The plugin returns an array of sub-plugins, all using `enforce: 'pre'`, so it must be the FIRST plugin in the Vite config.
+
+## Installation and Basic Setup
+
+```ts
+// vite.config.ts
+import { devtools } from '@tanstack/devtools-vite'
+
+export default {
+  plugins: [
+    devtools(),
+    // ... other plugins AFTER devtools
+  ],
+}
+```
+
+Install as a dev dependency:
+
+```sh
+pnpm add -D @tanstack/devtools-vite
+```
+
+There is also a `defineDevtoolsConfig` helper for type-safe config objects:
+
+```ts
+import { devtools, defineDevtoolsConfig } from '@tanstack/devtools-vite'
+
+const config = defineDevtoolsConfig({
+  // fully typed options
+})
+
+export default {
+  plugins: [devtools(config)],
+}
+```
+
+## Exports
+
+From `packages/devtools-vite/src/index.ts`:
+
+- `devtools` -- main plugin factory, returns `Array<Plugin>`
+- `defineDevtoolsConfig` -- identity function for type-safe config
+- `TanStackDevtoolsViteConfig` -- config type (re-exported)
+- `ConsoleLevel` -- `'log' | 'warn' | 'error' | 'info' | 'debug'`
+
+## Architecture: Sub-Plugins
+
+`devtools()` returns an array of Vite plugins. Each has `enforce: 'pre'` and only activates when its conditions are met (dev mode, serve command, etc.).
+
+| Sub-plugin name                               | What it does                                                                                                       | When active                                                |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| `@tanstack/devtools:inject-source`            | Babel transform adding `data-tsd-source` attrs to JSX                                                              | dev mode + `injectSource.enabled`                          |
+| `@tanstack/devtools:config`                   | Reserved for future config modifications                                                                           | serve command only                                         |
+| `@tanstack/devtools:custom-server`            | Starts ServerEventBus, registers middleware for open-source/console-pipe endpoints                                 | dev mode                                                   |
+| `@tanstack/devtools:remove-devtools-on-build` | Strips devtools imports/JSX from production bundles                                                                | build command or production mode + `removeDevtoolsOnBuild` |
+| `@tanstack/devtools:event-client-setup`       | Marketplace: listens for install/add-plugin events via devtoolsEventClient                                         | dev mode + serve + not CI                                  |
+| `@tanstack/devtools:console-pipe-transform`   | Injects runtime console-pipe code into entry files                                                                 | dev mode + serve + `consolePiping.enabled`                 |
+| `@tanstack/devtools:better-console-logs`      | Babel transform prepending source location to `console.log`/`console.error`                                        | dev mode + `enhancedLogs.enabled`                          |
+| `@tanstack/devtools:inject-plugin`            | Detects which file imports TanStackDevtools (for marketplace injection)                                            | dev mode + serve                                           |
+| `@tanstack/devtools:connection-injection`     | Replaces `__TANSTACK_DEVTOOLS_PORT__`, `__TANSTACK_DEVTOOLS_HOST__`, `__TANSTACK_DEVTOOLS_PROTOCOL__` placeholders | dev mode + serve                                           |
+
+## Subsystem Details
+
+### Source Injection
+
+Adds `data-tsd-source="<relative-path>:<line>:<column>"` attributes to every JSX opening element via Babel. This powers the "Go to Source" feature -- hold the inspect hotkey (default: Shift+Alt+Ctrl/Meta), hover over elements, click to open in editor.
+
+**Key behaviors:**
+
+- Skips `<Fragment>` and `<React.Fragment>`
+- Skips elements where the component's props parameter is spread (`{...props}`) -- this is because injecting the attribute would be overwritten by the spread
+- Skips files matching `injectSource.ignore.files` patterns
+- Skips components matching `injectSource.ignore.components` patterns
+- Patterns can be strings (matched via picomatch) or RegExp
+- Transform filter excludes `node_modules`, `?raw` imports, `/dist/`, `/build/`
+
+**Source files:** `packages/devtools-vite/src/inject-source.ts`, `packages/devtools-vite/src/matcher.ts`
+
+```ts
+devtools({
+  injectSource: {
+    enabled: true,
+    ignore: {
+      files: ['node_modules', /.*\.test\.(js|ts|jsx|tsx)$/],
+      components: ['InternalComponent', /.*Provider$/],
+    },
+  },
+})
+```
+
+### Console Piping
+
+Bidirectional console piping between client and server. Injects runtime code (IIFE) into entry files that:
+
+**Client side:**
+
+1. Wraps `console[level]` to batch and POST entries to `/__tsd/console-pipe`
+2. Opens an EventSource on `/__tsd/console-pipe/sse` to receive server logs
+3. Server logs appear in browser console with a purple `[Server]` prefix
+4. Client logs appear in terminal with a cyan `[Client]` prefix
+
+**Server side (SSR/Nitro):**
+
+1. Wraps `console[level]` to batch and POST entries to `<viteServerUrl>/__tsd/console-pipe/server`
+2. These are then broadcast to all SSE clients
+
+**Entry file detection:** looks for `<html` tag, `StartClient`, `hydrateRoot`, `createRoot`, or `solid-js/web` + `render(` in code.
+
+**Source files:** `packages/devtools-vite/src/virtual-console.ts`, `packages/devtools-vite/src/utils.ts` (middleware handlers)
+
+```ts
+devtools({
+  consolePiping: {
+    enabled: true,
+    levels: ['log', 'warn', 'error', 'info', 'debug'],
+  },
+})
+```
+
+### Enhanced Logging
+
+Babel transform that prepends source location info to `console.log()` and `console.error()` calls. In the browser, this renders as a clickable "Go to Source" link. On the server, it shows `LOG <path>:<line>:<column>` in chalk colors.
+
+The transform inserts a spread of a conditional expression: `...(typeof window === 'undefined' ? serverLogMessage : browserLogMessage)` as the first argument of the console call.
+
+**Source file:** `packages/devtools-vite/src/enhance-logs.ts`
+
+```ts
+devtools({
+  enhancedLogs: {
+    enabled: true, // default
+  },
+})
+```
+
+### Production Stripping
+
+Removes all devtools code from production builds. The transform:
+
+1. Finds files importing from these packages: `@tanstack/react-devtools`, `@tanstack/preact-devtools`, `@tanstack/solid-devtools`, `@tanstack/vue-devtools`, `@tanstack/devtools`
+2. Removes the import declarations
+3. Removes the JSX elements that use the imported components
+4. Cleans up leftover imports that were only used inside the removed JSX (e.g., plugin panel components)
+
+Active when: `command !== 'serve'` OR `config.mode === 'production'` (handles hosting providers like Cloudflare/Netlify that may not use `build` command but set mode to production).
+
+**Source file:** `packages/devtools-vite/src/remove-devtools.ts`
+
+```ts
+devtools({
+  removeDevtoolsOnBuild: true, // default
+})
+```
+
+### Server Event Bus
+
+A WebSocket + SSE server for devtools-to-client communication. Managed by `@tanstack/devtools-event-bus/server`.
+
+**Key behaviors:**
+
+- Default port: 4206
+- On EADDRINUSE: falls back to OS-assigned port (port 0)
+- When Vite uses HTTPS: piggybacks on Vite's httpServer instead of creating a standalone one (shares TLS certificate)
+- Uses global variables (`__TANSTACK_DEVTOOLS_SERVER__`, etc.) to survive HMR without restarting
+- The actual port is injected into client code via `__TANSTACK_DEVTOOLS_PORT__` placeholder replacement
+
+**Source file:** `packages/event-bus/src/server/server.ts`
+
+```ts
+devtools({
+  eventBusConfig: {
+    port: 4206, // default
+    enabled: true, // default; set false for storybook/vitest
+    debug: false, // default; logs internal bus activity
+  },
+})
+```
+
+### Editor Integration
+
+Uses `launch-editor` to open source files in the editor. Default editor is VS Code. The `editor.open` callback receives `(path, lineNumber, columnNumber)` as strings.
+
+The open-source flow: browser requests `/__tsd/open-source?source=<encoded-path:line:col>` --> Vite middleware parses source param --> calls `editor.open`.
+
+Supported editors via launch-editor: VS Code, WebStorm, Sublime Text, Atom, and more. For unsupported editors, provide a custom `editor.open` function.
+
+**Source file:** `packages/devtools-vite/src/editor.ts`
+
+```ts
+devtools({
+  editor: {
+    name: 'Cursor',
+    open: async (path, lineNumber, columnNumber) => {
+      // Custom editor open logic
+      // path is the absolute file path
+      // lineNumber and columnNumber are strings or undefined
+    },
+  },
+})
+```
+
+### Plugin Marketplace
+
+When the dev server is running, listens for events via `devtoolsEventClient`:
+
+- `install-devtools` -- runs package manager install, then auto-injects plugin into devtools setup file
+- `add-plugin-to-devtools` -- injects plugin import and JSX/function call into the file containing `<TanStackDevtools>`
+- `bump-package-version` -- updates a package to a minimum version
+- `mounted` -- sends package.json and outdated deps to the UI
+
+Auto-detection of the devtools setup file: the `inject-plugin` sub-plugin scans transforms for files importing from `@tanstack/react-devtools`, `@tanstack/solid-devtools`, `@tanstack/vue-devtools`, etc., and stores the file ID.
+
+**Source files:** `packages/devtools-vite/src/inject-plugin.ts`, `packages/devtools-vite/src/package-manager.ts`
+
+## Common Mistakes
+
+### 1. Not placing devtools() first in Vite plugins (HIGH)
+
+All sub-plugins use `enforce: 'pre'`. They must transform code before framework plugins (React, Vue, Solid, etc.) process it. If devtools is not first, source injection and enhanced logs may silently fail because framework transforms remove the raw JSX before devtools can annotate it.
+
+```ts
+// WRONG
+export default {
+  plugins: [
+    react(),
+    devtools(), // too late -- react() already transformed JSX
+  ],
+}
+
+// CORRECT
+export default {
+  plugins: [devtools(), react()],
+}
+```
+
+### 2. Using devtools-vite with non-Vite bundlers (HIGH)
+
+`@tanstack/devtools-vite` has a peer dependency on `vite ^6.0.0 || ^7.0.0`. It uses Vite-specific APIs (`configureServer`, `handleHotUpdate`, `transform` with filter objects, `Plugin` type). It will not work with webpack, rspack, esbuild, or other bundlers. For non-Vite setups, use `@tanstack/devtools-event-bus` client directly without the Vite plugin.
+
+### 3. Expecting Vite plugin features in production (MEDIUM)
+
+Source injection, console piping, enhanced logging, the server event bus, and the marketplace only operate during development (`config.mode === 'development'` and `command === 'serve'`). In production builds, the only active sub-plugin is `remove-devtools-on-build` (which strips devtools code). Do not rely on any of these features being available at runtime in production.
+
+### 4. Source injection on spread-props elements (MEDIUM)
+
+The Babel transform in `inject-source.ts` explicitly skips any JSX element that has a `{...props}` spread where `props` is the component's parameter name. This is intentional -- the spread would overwrite the injected `data-tsd-source` attribute. If source inspection doesn't work for a specific component, check if it spreads its props parameter.
+
+```tsx
+// data-tsd-source will NOT be injected on <div> here
+const MyComponent = (props) => {
+  return <div {...props}>content</div>
+}
+```
+
+### 5. Event bus port conflict in multi-project setups (MEDIUM)
+
+The default event bus port is 4206. When running multiple Vite dev servers concurrently (monorepo), the second server will hit EADDRINUSE. The event bus handles this by falling back to an OS-assigned port (port 0), and the actual port is injected via placeholder replacement. However, if you need predictable ports (e.g., for firewall rules), set different ports explicitly:
+
+```ts
+// Project A
+devtools({ eventBusConfig: { port: 4206 } })
+
+// Project B
+devtools({ eventBusConfig: { port: 4207 } })
+```
+
+## Internal Middleware Endpoints
+
+These are registered on the Vite dev server (not the event bus server):
+
+| Endpoint                                    | Method | Purpose                                                   |
+| ------------------------------------------- | ------ | --------------------------------------------------------- |
+| `/__tsd/open-source?source=<path:line:col>` | GET    | Opens file in editor, returns HTML that closes the window |
+| `/__tsd/console-pipe`                       | POST   | Receives client console entries (batched JSON)            |
+| `/__tsd/console-pipe/server`                | POST   | Receives server-side console entries                      |
+| `/__tsd/console-pipe/sse`                   | GET    | SSE stream for broadcasting server logs to browser        |
+
+## Cross-References
+
+- **devtools-app-setup** -- How to set up `<TanStackDevtools>` in your app (must be done before the Vite plugin provides value)
+- **devtools-production** -- Details on production stripping configuration and keeping devtools in production builds
+
+## Key Source Files
+
+- `packages/devtools-vite/src/plugin.ts` -- Main plugin factory with all sub-plugins and config type
+- `packages/devtools-vite/src/inject-source.ts` -- Babel transform for data-tsd-source injection
+- `packages/devtools-vite/src/enhance-logs.ts` -- Babel transform for enhanced console logs
+- `packages/devtools-vite/src/remove-devtools.ts` -- Production stripping transform
+- `packages/devtools-vite/src/virtual-console.ts` -- Console pipe runtime code generator
+- `packages/devtools-vite/src/editor.ts` -- Editor config type and launch-editor integration
+- `packages/devtools-vite/src/inject-plugin.ts` -- Marketplace plugin injection into devtools setup file
+- `packages/devtools-vite/src/utils.ts` -- Middleware request handling and helpers
+- `packages/devtools-vite/src/matcher.ts` -- Picomatch/RegExp pattern matcher
+- `packages/event-bus/src/server/server.ts` -- ServerEventBus implementation (WebSocket + SSE + EADDRINUSE fallback)

--- a/.agents/skills/devtools-vite-plugin/SKILL.md
+++ b/.agents/skills/devtools-vite-plugin/SKILL.md
@@ -6,10 +6,10 @@ description: >
   server-to-client, levels), enhanced logging, server event bus (port, host,
   HTTPS), production stripping (removeDevtoolsOnBuild), editor integration
   (launch-editor, custom editor.open). Must be FIRST plugin in Vite config.
-  Vite ^6 || ^7 only.
+  Supports Vite ^6, ^7, and ^8.
 type: core
 library: tanstack-devtools
-library_version: '0.10.12'
+library_version: '0.6.0'
 sources:
   - 'TanStack/devtools:docs/vite-plugin.md'
   - 'TanStack/devtools:docs/source-inspector.md'

--- a/.agents/skills/devtools-vite-plugin/references/vite-options.md
+++ b/.agents/skills/devtools-vite-plugin/references/vite-options.md
@@ -1,0 +1,413 @@
+# @tanstack/devtools-vite Options Reference
+
+Complete configuration reference for the `devtools()` Vite plugin. All options are optional -- calling `devtools()` with no arguments uses sensible defaults.
+
+**Source of truth:** `packages/devtools-vite/src/plugin.ts` (type `TanStackDevtoolsViteConfig`)
+
+## Top-Level Config Type
+
+```ts
+import type { Plugin } from 'vite'
+
+type ConsoleLevel = 'log' | 'warn' | 'error' | 'info' | 'debug'
+
+type TanStackDevtoolsViteConfig = {
+  editor?: EditorConfig
+  eventBusConfig?: ServerEventBusConfig & { enabled?: boolean }
+  enhancedLogs?: { enabled: boolean }
+  removeDevtoolsOnBuild?: boolean
+  logging?: boolean
+  injectSource?: {
+    enabled: boolean
+    ignore?: {
+      files?: Array<string | RegExp>
+      components?: Array<string | RegExp>
+    }
+  }
+  consolePiping?: {
+    enabled?: boolean
+    levels?: Array<ConsoleLevel>
+  }
+}
+
+// Returns Array<Plugin> (9 sub-plugins)
+declare function devtools(args?: TanStackDevtoolsViteConfig): Array<Plugin>
+
+// Identity function for type-safe config objects
+declare function defineDevtoolsConfig(
+  config: TanStackDevtoolsViteConfig,
+): TanStackDevtoolsViteConfig
+```
+
+---
+
+## `injectSource`
+
+Controls source injection -- the Babel transform that adds `data-tsd-source` attributes to JSX elements for the "Go to Source" feature.
+
+| Field               | Type                      | Default     | Description                                                                                                                                                                                              |
+| ------------------- | ------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`           | `boolean`                 | `true`      | Whether to inject `data-tsd-source` attributes into JSX elements during development.                                                                                                                     |
+| `ignore`            | `object`                  | `undefined` | Patterns to exclude from injection.                                                                                                                                                                      |
+| `ignore.files`      | `Array<string \| RegExp>` | `[]`        | File paths to skip. Strings are matched via picomatch glob syntax. RegExp patterns are tested directly. Matched against the file's path relative to `process.cwd()`.                                     |
+| `ignore.components` | `Array<string \| RegExp>` | `[]`        | Component/element names to skip. Strings are matched via picomatch. RegExp patterns are tested directly. Matched against the JSX element name (e.g., `"div"`, `"MyComponent"`, `"Namespace.Component"`). |
+
+**Built-in exclusions (hardcoded in transform filter, not configurable):**
+
+- `node_modules`
+- `?raw` imports
+- `/dist/` paths
+- `/build/` paths
+- `<Fragment>` and `<React.Fragment>` elements
+- Elements with `{...propsParam}` spread (where `propsParam` is the function's parameter name)
+
+**Example:**
+
+```ts
+devtools({
+  injectSource: {
+    enabled: true,
+    ignore: {
+      files: ['node_modules', /.*\.test\.(js|ts|jsx|tsx)$/, '**/generated/**'],
+      components: ['InternalComponent', /.*Provider$/, /^Styled/],
+    },
+  },
+})
+```
+
+---
+
+## `consolePiping`
+
+Controls bidirectional console log piping between client (browser) and server (terminal/SSR runtime).
+
+| Field     | Type                  | Default                                     | Description                                                                                                                                                                |
+| --------- | --------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled` | `boolean`             | `true`                                      | Whether to enable console piping. When enabled, client `console.*` calls are forwarded to the terminal, and server `console.*` calls are forwarded to the browser console. |
+| `levels`  | `Array<ConsoleLevel>` | `['log', 'warn', 'error', 'info', 'debug']` | Which console methods to intercept and pipe. `ConsoleLevel` is `'log' \| 'warn' \| 'error' \| 'info' \| 'debug'`.                                                          |
+
+**Runtime behavior:**
+
+- Client batches entries (max 50, flush after 100ms) and POSTs to `/__tsd/console-pipe`
+- Server batches entries (max 20, flush after 50ms) and POSTs to `<viteServerUrl>/__tsd/console-pipe/server`
+- Browser subscribes to server logs via `EventSource` at `/__tsd/console-pipe/sse`
+- Self-referential log messages (containing `[TSD Console Pipe]` or `[@tanstack/devtools`) are excluded to prevent recursion
+- Flushes remaining batch on `beforeunload` (client only)
+
+**Example:**
+
+```ts
+// Only pipe errors and warnings
+devtools({
+  consolePiping: {
+    enabled: true,
+    levels: ['error', 'warn'],
+  },
+})
+
+// Disable entirely
+devtools({
+  consolePiping: {
+    enabled: false,
+  },
+})
+```
+
+---
+
+## `enhancedLogs`
+
+Controls the Babel transform that prepends source location information to `console.log()` and `console.error()` calls.
+
+| Field     | Type      | Default | Description                                                                                                                                                                                           |
+| --------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled` | `boolean` | `true`  | Whether to enhance console.log and console.error with source location. When enabled, each log call gets a clickable "Go to Source" link in the browser and a file:line:column prefix in the terminal. |
+
+**What gets transformed:**
+
+- Only `console.log(...)` and `console.error(...)` calls (not `warn`, `info`, `debug`)
+- Skips `node_modules`, `?raw`, `/dist/`, `/build/`
+- Skips files that don't contain the string `console.`
+
+**Browser output format:**
+
+```
+%cLOG%c %cGo to Source: http://localhost:5173/__tsd/open-source?source=...%c
+ -> <original args>
+```
+
+**Server output format (chalk):**
+
+```
+LOG /src/components/Header.tsx:26:13
+ -> <original args>
+```
+
+**Example:**
+
+```ts
+devtools({
+  enhancedLogs: {
+    enabled: false, // disable source-annotated logs
+  },
+})
+```
+
+---
+
+## `removeDevtoolsOnBuild`
+
+Controls whether devtools code is stripped from production builds.
+
+| Field                   | Type      | Default | Description                                                                   |
+| ----------------------- | --------- | ------- | ----------------------------------------------------------------------------- |
+| `removeDevtoolsOnBuild` | `boolean` | `true`  | When true, removes all devtools imports and JSX usage from production builds. |
+
+**Packages stripped:**
+
+- `@tanstack/react-devtools`
+- `@tanstack/preact-devtools`
+- `@tanstack/solid-devtools`
+- `@tanstack/vue-devtools`
+- `@tanstack/devtools`
+
+**Activation condition:** Active when `command !== 'serve'` OR `config.mode === 'production'`. This dual check supports hosting providers (Cloudflare, Netlify, Heroku) that may not use the `build` command but always set mode to `production`.
+
+**What gets removed:**
+
+1. Import declarations from the listed packages
+2. JSX elements using the imported component names
+3. Leftover imports that were only referenced inside the removed JSX (e.g., plugin panel components referenced in the `plugins` prop)
+
+**Example:**
+
+```ts
+// Keep devtools in production (for staging/QA environments)
+devtools({
+  removeDevtoolsOnBuild: false,
+})
+```
+
+---
+
+## `logging`
+
+Controls the plugin's own console output.
+
+| Field     | Type      | Default | Description                                                                                                 |
+| --------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `logging` | `boolean` | `true`  | Whether the devtools plugin logs status messages to the terminal (e.g., "Removed devtools code from: ..."). |
+
+**Example:**
+
+```ts
+devtools({
+  logging: false, // suppress devtools plugin output
+})
+```
+
+---
+
+## `eventBusConfig`
+
+Configuration for the server event bus that handles devtools-to-client communication via WebSocket and SSE.
+
+| Field        | Type             | Default                                                     | Description                                                                                                                                                                                                                                                                                |
+| ------------ | ---------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`    | `boolean`        | `true`                                                      | Whether to start the server event bus. Set to `false` when running devtools in environments that don't need it (e.g., Storybook, Vitest). This field is specific to the Vite plugin wrapper; it is not part of `ServerEventBusConfig` from `@tanstack/devtools-event-bus/server`.          |
+| `port`       | `number`         | `4206`                                                      | Preferred port for the event bus server. If the port is in use (EADDRINUSE), the bus falls back to an OS-assigned port (port 0).                                                                                                                                                           |
+| `host`       | `string`         | Derived from `server.host` in Vite config, or `'localhost'` | Hostname to bind the event bus server to.                                                                                                                                                                                                                                                  |
+| `debug`      | `boolean`        | `false`                                                     | When true, logs internal event bus activity (connections, dispatches, etc.) to the console.                                                                                                                                                                                                |
+| `httpServer` | `HttpServerLike` | `undefined`                                                 | An external HTTP server to attach to instead of creating a standalone one. The Vite plugin automatically sets this when HTTPS is enabled (uses `server.httpServer` from Vite) so WebSocket/SSE connections share the same TLS certificate. You generally do not need to set this manually. |
+
+**`HttpServerLike` interface:**
+
+```ts
+interface HttpServerLike {
+  on: (event: string, listener: (...args: Array<any>) => void) => this
+  removeListener: (
+    event: string,
+    listener: (...args: Array<any>) => void,
+  ) => this
+  address: () =>
+    | { port: number; family: string; address: string }
+    | string
+    | null
+}
+```
+
+**`ServerEventBusConfig` type (from `@tanstack/devtools-event-bus/server`):**
+
+```ts
+interface ServerEventBusConfig {
+  port?: number | undefined
+  host?: string | undefined
+  debug?: boolean | undefined
+  httpServer?: HttpServerLike | undefined
+}
+```
+
+**HTTPS behavior:** When `server.https` is configured in Vite, the plugin passes `server.httpServer` as `httpServer` to the event bus. This causes the bus to piggyback on Vite's server rather than creating a standalone HTTP server, ensuring WebSocket and SSE connections use the same TLS certificate.
+
+**Port fallback:** The `ServerEventBus.start()` method tries the configured port first. On `EADDRINUSE`, it retries with port 0 (OS-assigned). The actual port is stored and injected into client code via `__TANSTACK_DEVTOOLS_PORT__` placeholder.
+
+**Example:**
+
+```ts
+devtools({
+  eventBusConfig: {
+    port: 4300,
+    enabled: true,
+    debug: true, // see all event bus activity
+  },
+})
+
+// Disable for Storybook
+devtools({
+  eventBusConfig: {
+    enabled: false,
+  },
+})
+```
+
+---
+
+## `editor`
+
+Configuration for the "open in editor" functionality used by the source inspector.
+
+| Field  | Type                                                                                      | Default                              | Description                                                                                                                                                     |
+| ------ | ----------------------------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` | `string`                                                                                  | `'VSCode'`                           | Name of the editor, used for debugging/logging purposes.                                                                                                        |
+| `open` | `(path: string, lineNumber: string \| undefined, columnNumber?: string) => Promise<void>` | Uses `launch-editor` to open VS Code | Callback function that opens a file in the editor. The `path` is an absolute file path. `lineNumber` and `columnNumber` are strings (not numbers) or undefined. |
+
+**`EditorConfig` type (from `packages/devtools-vite/src/editor.ts`):**
+
+```ts
+type EditorConfig = {
+  name: string
+  open: (
+    path: string,
+    lineNumber: string | undefined,
+    columnNumber?: string,
+  ) => Promise<void>
+}
+```
+
+**Default implementation:**
+
+```ts
+const DEFAULT_EDITOR_CONFIG: EditorConfig = {
+  name: 'VSCode',
+  open: async (path, lineNumber, columnNumber) => {
+    const launch = (await import('launch-editor')).default
+    launch(
+      `${path.replaceAll('$', '\\$')}${lineNumber ? `:${lineNumber}` : ''}${columnNumber ? `:${columnNumber}` : ''}`,
+      undefined,
+      (filename, err) => {
+        console.warn(`Failed to open ${filename} in editor: ${err}`)
+      },
+    )
+  },
+}
+```
+
+**Supported editors via launch-editor:** VS Code, WebStorm, IntelliJ IDEA, Sublime Text, Atom, Vim, Emacs, and more. Full list: https://github.com/yyx990803/launch-editor#supported-editors
+
+**Example -- custom editor:**
+
+```ts
+devtools({
+  editor: {
+    name: 'Neovim',
+    open: async (path, lineNumber, columnNumber) => {
+      const { execFile } = await import('node:child_process')
+      const lineArg = lineNumber ? `+${lineNumber}` : ''
+      execFile('nvim', [lineArg, path].filter(Boolean))
+    },
+  },
+})
+```
+
+---
+
+## Connection Placeholders
+
+These are not user-facing config options but are relevant if you work on `@tanstack/devtools` internals. The `connection-injection` sub-plugin replaces these string literals in `@tanstack/devtools*` and `@tanstack/event-bus` source code during dev:
+
+| Placeholder                      | Replaced with                       | Fallback      |
+| -------------------------------- | ----------------------------------- | ------------- |
+| `__TANSTACK_DEVTOOLS_PORT__`     | Actual event bus port (number)      | `4206`        |
+| `__TANSTACK_DEVTOOLS_HOST__`     | Event bus hostname (JSON string)    | `"localhost"` |
+| `__TANSTACK_DEVTOOLS_PROTOCOL__` | `"http"` or `"https"` (JSON string) | `"http"`      |
+
+---
+
+## Full Configuration Example
+
+```ts
+import { devtools } from '@tanstack/devtools-vite'
+
+export default {
+  plugins: [
+    devtools({
+      // Source injection for Go to Source feature
+      injectSource: {
+        enabled: true,
+        ignore: {
+          files: [/.*\.stories\.(js|ts|jsx|tsx)$/],
+          components: [/^Styled/, 'InternalWrapper'],
+        },
+      },
+
+      // Bidirectional console piping
+      consolePiping: {
+        enabled: true,
+        levels: ['log', 'warn', 'error'],
+      },
+
+      // Enhanced console.log/error with source locations
+      enhancedLogs: {
+        enabled: true,
+      },
+
+      // Strip devtools from production builds
+      removeDevtoolsOnBuild: true,
+
+      // Plugin console output
+      logging: true,
+
+      // Server event bus
+      eventBusConfig: {
+        port: 4206,
+        enabled: true,
+        debug: false,
+      },
+
+      // Editor integration (default: VS Code via launch-editor)
+      // editor: { name: 'VSCode', open: async (path, line, col) => { ... } },
+    }),
+    // ... framework plugin (react(), vue(), solid(), etc.)
+  ],
+}
+```
+
+---
+
+## Defaults Summary
+
+| Option                   | Default Value                               |
+| ------------------------ | ------------------------------------------- |
+| `injectSource.enabled`   | `true`                                      |
+| `injectSource.ignore`    | `undefined` (no ignores)                    |
+| `consolePiping.enabled`  | `true`                                      |
+| `consolePiping.levels`   | `['log', 'warn', 'error', 'info', 'debug']` |
+| `enhancedLogs.enabled`   | `true`                                      |
+| `removeDevtoolsOnBuild`  | `true`                                      |
+| `logging`                | `true`                                      |
+| `eventBusConfig.enabled` | `true`                                      |
+| `eventBusConfig.port`    | `4206`                                      |
+| `eventBusConfig.host`    | Vite's `server.host` or `'localhost'`       |
+| `eventBusConfig.debug`   | `false`                                     |
+| `editor.name`            | `'VSCode'`                                  |
+| `editor.open`            | Uses `launch-editor`                        |

--- a/.agents/skills/meta-framework/SKILL.md
+++ b/.agents/skills/meta-framework/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: meta-framework
+description: >
+  Integrating TanStack DB with meta-frameworks (TanStack Start, Next.js,
+  Remix, Nuxt, SvelteKit). Client-side only: SSR is NOT supported — routes
+  must disable SSR. Preloading collections in route loaders with
+  collection.preload(). Pattern: ssr: false + await collection.preload() in
+  loader. Multiple collection preloading with Promise.all. Framework-specific
+  loader APIs.
+type: composition
+library: db
+library_version: '0.6.0'
+requires:
+  - db-core
+  - db-core/collection-setup
+sources:
+  - 'TanStack/db:examples/react/todo/src/routes/electric.tsx'
+  - 'TanStack/db:examples/react/todo/src/routes/query.tsx'
+  - 'TanStack/db:examples/react/todo/src/start.tsx'
+---
+
+This skill builds on db-core. Read it first for collection setup and query builder.
+
+# TanStack DB — Meta-Framework Integration
+
+## Setup
+
+TanStack DB collections are **client-side only**. SSR is not implemented. Routes using TanStack DB **must disable SSR**. The setup pattern is:
+
+1. Set `ssr: false` on the route
+2. Call `collection.preload()` in the route loader
+3. Use `useLiveQuery` in the component
+
+## TanStack Start
+
+### Global SSR disable
+
+```ts
+// start.tsx
+import { createStart } from '@tanstack/react-start'
+
+export const startInstance = createStart(() => {
+  return {
+    defaultSsr: false,
+  }
+})
+```
+
+### Per-route SSR disable + preload
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { useLiveQuery } from '@tanstack/react-db'
+
+export const Route = createFileRoute('/todos')({
+  ssr: false,
+  loader: async () => {
+    await todoCollection.preload()
+    return null
+  },
+  component: TodoPage,
+})
+
+function TodoPage() {
+  const { data: todos } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+  return (
+    <ul>
+      {todos.map((t) => (
+        <li key={t.id}>{t.text}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### Multiple collection preloading
+
+```tsx
+export const Route = createFileRoute('/electric')({
+  ssr: false,
+  loader: async () => {
+    await Promise.all([todoCollection.preload(), configCollection.preload()])
+    return null
+  },
+  component: ElectricPage,
+})
+```
+
+## Next.js (App Router)
+
+### Client component with preloading
+
+```tsx
+// app/todos/page.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useLiveQuery } from '@tanstack/react-db'
+
+export default function TodoPage() {
+  const { data: todos, isLoading } = useLiveQuery((q) =>
+    q.from({ todo: todoCollection }),
+  )
+
+  if (isLoading) return <div>Loading...</div>
+  return (
+    <ul>
+      {todos.map((t) => (
+        <li key={t.id}>{t.text}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+Next.js App Router components using TanStack DB must be client components (`'use client'`). There is no server-side preloading — collections sync on mount.
+
+### With route-level preloading (experimental)
+
+```tsx
+// app/todos/page.tsx
+'use client'
+
+import { useEffect } from 'react'
+import { useLiveQuery } from '@tanstack/react-db'
+
+// Trigger preload immediately when module is loaded
+const preloadPromise = todoCollection.preload()
+
+export default function TodoPage() {
+  const { data: todos } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+  return (
+    <ul>
+      {todos.map((t) => (
+        <li key={t.id}>{t.text}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Remix
+
+### Client loader pattern
+
+```tsx
+// app/routes/todos.tsx
+import { useLiveQuery } from '@tanstack/react-db'
+import type { ClientLoaderFunctionArgs } from '@remix-run/react'
+
+export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
+  await todoCollection.preload()
+  return null
+}
+
+// Prevent server loader from running
+export const loader = () => null
+
+export default function TodoPage() {
+  const { data: todos } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+  return (
+    <ul>
+      {todos.map((t) => (
+        <li key={t.id}>{t.text}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Nuxt
+
+### Client-only component
+
+```vue
+<!-- pages/todos.vue -->
+<script setup lang="ts">
+import { useLiveQuery } from '@tanstack/vue-db'
+
+const { data: todos, isLoading } = useLiveQuery((q) =>
+  q.from({ todo: todoCollection }),
+)
+</script>
+
+<template>
+  <ClientOnly>
+    <div v-if="isLoading">Loading...</div>
+    <ul v-else>
+      <li v-for="todo in todos" :key="todo.id">{{ todo.text }}</li>
+    </ul>
+  </ClientOnly>
+</template>
+```
+
+Wrap TanStack DB components in `<ClientOnly>` to prevent SSR.
+
+## SvelteKit
+
+### Client-side only page
+
+```svelte
+<!-- src/routes/todos/+page.svelte -->
+<script lang="ts">
+  import { browser } from '$app/environment'
+  import { useLiveQuery } from '@tanstack/svelte-db'
+
+  const todosQuery = browser
+    ? useLiveQuery((q) => q.from({ todo: todoCollection }))
+    : null
+</script>
+
+{#if todosQuery}
+  {#each todosQuery.data as todo (todo.id)}
+    <li>{todo.text}</li>
+  {/each}
+{/if}
+```
+
+Or disable SSR for the route:
+
+```ts
+// src/routes/todos/+page.ts
+export const ssr = false
+```
+
+## Core Patterns
+
+### What preload() does
+
+`collection.preload()` starts the sync process and returns a promise that resolves when the collection reaches "ready" status. This means:
+
+1. The sync function connects to the backend
+2. Initial data is fetched and written to the collection
+3. `markReady()` is called by the adapter
+4. The promise resolves
+
+Subsequent calls to `preload()` on an already-ready collection return immediately.
+
+### Collection module pattern
+
+Define collections in a shared module, import in both loaders and components:
+
+```ts
+// lib/collections.ts
+import { createCollection, queryCollectionOptions } from '@tanstack/react-db'
+
+export const todoCollection = createCollection(
+  queryCollectionOptions({ ... })
+)
+```
+
+```tsx
+// routes/todos.tsx — loader uses the same collection instance
+import { todoCollection } from '../lib/collections'
+
+export const Route = createFileRoute('/todos')({
+  ssr: false,
+  loader: async () => {
+    await todoCollection.preload()
+    return null
+  },
+  component: () => {
+    const { data } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+    // ...
+  },
+})
+```
+
+## Server-Side Integration
+
+This skill covers the **client-side** read path only (preloading, live queries). For server-side concerns:
+
+- **Electric proxy route** (forwarding shape requests to Electric) — see the [Electric adapter reference](../db-core/collection-setup/references/electric-adapter.md)
+- **Mutation endpoints** (`createServerFn` in TanStack Start, API routes in Next.js/Remix) — implement using your framework's server function pattern. See the Electric adapter reference for the txid handshake that mutations must return.
+
+## Common Mistakes
+
+### CRITICAL Enabling SSR with TanStack DB
+
+Wrong:
+
+```tsx
+export const Route = createFileRoute('/todos')({
+  loader: async () => {
+    await todoCollection.preload()
+    return null
+  },
+})
+```
+
+Correct:
+
+```tsx
+export const Route = createFileRoute('/todos')({
+  ssr: false,
+  loader: async () => {
+    await todoCollection.preload()
+    return null
+  },
+})
+```
+
+TanStack DB collections are client-side only. Without `ssr: false`, the route loader runs on the server where collections cannot sync, causing hangs or errors.
+
+Source: examples/react/todo/src/start.tsx
+
+### HIGH Forgetting to preload in route loader
+
+Wrong:
+
+```tsx
+export const Route = createFileRoute('/todos')({
+  ssr: false,
+  component: TodoPage,
+})
+```
+
+Correct:
+
+```tsx
+export const Route = createFileRoute('/todos')({
+  ssr: false,
+  loader: async () => {
+    await todoCollection.preload()
+    return null
+  },
+  component: TodoPage,
+})
+```
+
+Without preloading, the collection starts syncing only when the component mounts, causing a loading flash. Preloading in the route loader starts sync during navigation, making data available immediately when the component renders.
+
+### MEDIUM Creating separate collection instances
+
+Wrong:
+
+```tsx
+// routes/todos.tsx
+const todoCollection = createCollection(queryCollectionOptions({ ... }))
+
+export const Route = createFileRoute('/todos')({
+  ssr: false,
+  loader: async () => { await todoCollection.preload() },
+  component: () => {
+    const { data } = useLiveQuery((q) => q.from({ todo: todoCollection }))
+  },
+})
+```
+
+Correct:
+
+```ts
+// lib/collections.ts — single shared instance
+export const todoCollection = createCollection(queryCollectionOptions({ ... }))
+```
+
+Collections are singletons. Creating multiple instances for the same data causes duplicate syncs, wasted bandwidth, and inconsistent state between components.
+
+See also: react-db/SKILL.md, vue-db/SKILL.md, svelte-db/SKILL.md, solid-db/SKILL.md, angular-db/SKILL.md — for framework-specific hook usage.
+
+See also: db-core/collection-setup/SKILL.md — for collection creation and adapter selection.

--- a/.agents/skills/meta-framework/SKILL.md
+++ b/.agents/skills/meta-framework/SKILL.md
@@ -242,7 +242,8 @@ Define collections in a shared module, import in both loaders and components:
 
 ```ts
 // lib/collections.ts
-import { createCollection, queryCollectionOptions } from '@tanstack/react-db'
+import { createCollection } from '@tanstack/react-db'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
 
 export const todoCollection = createCollection(
   queryCollectionOptions({ ... })

--- a/.agents/skills/meta-framework/SKILL.md
+++ b/.agents/skills/meta-framework/SKILL.md
@@ -356,6 +356,9 @@ export const todoCollection = createCollection(queryCollectionOptions({ ... }))
 
 Collections are singletons. Creating multiple instances for the same data causes duplicate syncs, wasted bandwidth, and inconsistent state between components.
 
-See also: react-db/SKILL.md, vue-db/SKILL.md, svelte-db/SKILL.md, solid-db/SKILL.md, angular-db/SKILL.md — for framework-specific hook usage.
+See also the framework package APIs (`@tanstack/react-db`, `@tanstack/vue-db`,
+`@tanstack/svelte-db`, `@tanstack/solid-db`, `@tanstack/angular-db`) for
+framework-specific hook usage. This repo does not install separate local
+framework-specific DB skills.
 
 See also: db-core/collection-setup/SKILL.md — for collection creation and adapter selection.

--- a/.agents/skills/tanstack-router-core-auth-and-guards/SKILL.md
+++ b/.agents/skills/tanstack-router-core-auth-and-guards/SKILL.md
@@ -10,8 +10,8 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
-  - router-core/data-loading
+  - tanstack-router-core
+  - tanstack-router-core-data-loading
 sources:
   - TanStack/router:docs/router/guide/authenticated-routes.md
   - TanStack/router:docs/router/how-to/setup-authentication.md

--- a/.agents/skills/tanstack-router-core-auth-and-guards/SKILL.md
+++ b/.agents/skills/tanstack-router-core-auth-and-guards/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   for auth state.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
   - tanstack-router-core-data-loading
@@ -455,4 +455,4 @@ Place protected routes as children of the `_authenticated` layout route. Public 
 
 ## Cross-References
 
-- See also: **router-core/data-loading/SKILL.md** — `beforeLoad` runs before `loader`; auth context flows into loader via route context
+- See also: **tanstack-router-core-data-loading/SKILL.md** — `beforeLoad` runs before `loader`; auth context flows into loader via route context

--- a/.agents/skills/tanstack-router-core-auth-and-guards/SKILL.md
+++ b/.agents/skills/tanstack-router-core-auth-and-guards/SKILL.md
@@ -1,0 +1,458 @@
+---
+name: tanstack-router-core-auth-and-guards
+description: >-
+  Route protection with beforeLoad, redirect()/throw redirect(),
+  isRedirect helper, authenticated layout routes (_authenticated),
+  non-redirect auth (inline login), RBAC with roles and permissions,
+  auth provider integration (Auth0, Clerk, Supabase), router context
+  for auth state.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+  - router-core/data-loading
+sources:
+  - TanStack/router:docs/router/guide/authenticated-routes.md
+  - TanStack/router:docs/router/how-to/setup-authentication.md
+  - TanStack/router:docs/router/how-to/setup-auth-providers.md
+  - TanStack/router:docs/router/how-to/setup-rbac.md
+---
+
+# Auth and Guards
+
+## Setup
+
+Protect routes with `beforeLoad` + `redirect()` in a pathless layout route (`_authenticated`):
+
+```tsx
+// src/routes/_authenticated.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/login',
+        search: {
+          redirect: location.href,
+        },
+      })
+    }
+  },
+  // component defaults to Outlet — no need to declare it
+})
+```
+
+Any route file placed under `src/routes/_authenticated/` is automatically protected:
+
+```tsx
+// src/routes/_authenticated/dashboard.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  component: DashboardComponent,
+})
+
+function DashboardComponent() {
+  const { auth } = Route.useRouteContext()
+  return <div>Welcome, {auth.user?.username}</div>
+}
+```
+
+## Core Patterns
+
+### Router Context for Auth State
+
+Auth state flows into the router via `createRootRouteWithContext` and `RouterProvider`'s `context` prop:
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: { id: string; username: string; email: string } | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+interface MyRouterContext {
+  auth: AuthState
+}
+
+export const Route = createRootRouteWithContext<MyRouterContext>()({
+  component: () => <Outlet />,
+})
+```
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export const router = createRouter({
+  routeTree,
+  context: {
+    auth: undefined!, // placeholder — filled by RouterProvider context prop
+  },
+})
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+
+```tsx
+// src/App.tsx
+import { RouterProvider } from '@tanstack/react-router'
+import { AuthProvider, useAuth } from './auth'
+import { router } from './router'
+
+function InnerApp() {
+  const auth = useAuth()
+  // context prop injects live auth state WITHOUT recreating the router
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <InnerApp />
+    </AuthProvider>
+  )
+}
+```
+
+The router is created once with a placeholder. `RouterProvider`'s `context` prop injects the live auth state on each render — this avoids recreating the router on auth changes (which would reset caches and rebuild the route tree).
+
+### Redirect-Based Auth with Redirect-Back
+
+Save the current location in search params so you can redirect back after login:
+
+```tsx
+// src/routes/_authenticated.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/login',
+        search: { redirect: location.href },
+      })
+    }
+  },
+})
+```
+
+```tsx
+// src/routes/login.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { useState, type FormEvent } from 'react'
+
+// Validate redirect target to prevent open redirect attacks
+function sanitizeRedirect(url: unknown): string {
+  if (typeof url !== 'string' || !url.startsWith('/') || url.startsWith('//')) {
+    return '/'
+  }
+  return url
+}
+
+export const Route = createFileRoute('/login')({
+  validateSearch: (search) => ({
+    redirect: sanitizeRedirect(search.redirect),
+  }),
+  beforeLoad: ({ context, search }) => {
+    if (context.auth.isAuthenticated) {
+      throw redirect({ to: search.redirect })
+    }
+  },
+  component: LoginComponent,
+})
+
+function LoginComponent() {
+  const { auth } = Route.useRouteContext()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await auth.login(username, password)
+      navigate({ to: search.redirect })
+    } catch {
+      setError('Invalid credentials')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {error && <div>{error}</div>}
+      <input value={username} onChange={(e) => setUsername(e.target.value)} />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Sign In</button>
+    </form>
+  )
+}
+```
+
+### Non-Redirect Auth (Inline Login)
+
+Instead of redirecting, show a login form in place of the `Outlet`:
+
+```tsx
+// src/routes/_authenticated.tsx
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  component: AuthenticatedLayout,
+})
+
+function AuthenticatedLayout() {
+  const { auth } = Route.useRouteContext()
+
+  if (!auth.isAuthenticated) {
+    return <LoginForm />
+  }
+
+  return <Outlet />
+}
+```
+
+This keeps the URL unchanged — the user stays on the same page and sees a login form instead of protected content. After authentication, `<Outlet />` renders and child routes appear.
+
+### RBAC with Roles and Permissions
+
+Extend auth state with role/permission helpers, then check in `beforeLoad`:
+
+```tsx
+// src/auth.tsx
+interface User {
+  id: string
+  username: string
+  email: string
+  roles: string[]
+  permissions: string[]
+}
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: User | null
+  hasRole: (role: string) => boolean
+  hasAnyRole: (roles: string[]) => boolean
+  hasPermission: (permission: string) => boolean
+  hasAnyPermission: (permissions: string[]) => boolean
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+```
+
+Admin-only layout route:
+
+```tsx
+// src/routes/_authenticated/_admin.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_admin')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.hasRole('admin')) {
+      throw redirect({
+        to: '/unauthorized',
+        search: { redirect: location.href },
+      })
+    }
+  },
+})
+```
+
+Multi-role access:
+
+```tsx
+// src/routes/_authenticated/_moderator.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_moderator')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.hasAnyRole(['admin', 'moderator'])) {
+      throw redirect({
+        to: '/unauthorized',
+        search: { redirect: location.href },
+      })
+    }
+  },
+})
+```
+
+Permission-based:
+
+```tsx
+// src/routes/_authenticated/_users.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_users')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.hasAnyPermission(['users:read', 'users:write'])) {
+      throw redirect({
+        to: '/unauthorized',
+        search: { redirect: location.href },
+      })
+    }
+  },
+})
+```
+
+Page-level permission check (nested under an already-role-protected layout):
+
+```tsx
+// src/routes/_authenticated/_users/manage.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_users/manage')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.hasPermission('users:write')) {
+      throw new Error('Write permission required')
+    }
+  },
+  component: UserManagement,
+})
+
+function UserManagement() {
+  const { auth } = Route.useRouteContext()
+  const canDelete = auth.hasPermission('users:delete')
+
+  return (
+    <div>
+      <h1>User Management</h1>
+      {canDelete && <button>Delete User</button>}
+    </div>
+  )
+}
+```
+
+### Handling Auth Check Failures (isRedirect)
+
+When `beforeLoad` has a try/catch, redirects (which work by throwing) can get swallowed. Use `isRedirect` to re-throw:
+
+```tsx
+import { createFileRoute, redirect, isRedirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: async ({ context, location }) => {
+    try {
+      const user = await verifySession(context.auth)
+      if (!user) {
+        throw redirect({
+          to: '/login',
+          search: { redirect: location.href },
+        })
+      }
+      return { user }
+    } catch (error) {
+      if (isRedirect(error)) throw error // re-throw redirect, don't swallow it
+      // Actual error — redirect to login
+      throw redirect({
+        to: '/login',
+        search: { redirect: location.href },
+      })
+    }
+  },
+})
+```
+
+## Common Mistakes
+
+### HIGH: Auth check in component instead of beforeLoad
+
+Component-level auth checks cause a **flash of protected content** before the redirect:
+
+```tsx
+// WRONG — protected content renders briefly before redirect
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  component: () => {
+    const auth = useAuth()
+    if (!auth.isAuthenticated) return <Navigate to="/login" />
+    return <Dashboard />
+  },
+})
+
+// CORRECT — beforeLoad runs before any rendering
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({ to: '/login' })
+    }
+  },
+  component: Dashboard,
+})
+```
+
+`beforeLoad` runs before any component rendering and before the loader. It completely prevents the flash.
+
+### HIGH: Not re-throwing redirects in try/catch
+
+`redirect()` works by throwing. If `beforeLoad` has a try/catch, the redirect gets swallowed:
+
+```tsx
+// WRONG — redirect is caught and swallowed
+beforeLoad: async ({ context }) => {
+  try {
+    await validateSession(context.auth)
+  } catch (e) {
+    console.error(e) // swallows the redirect!
+  }
+}
+
+// CORRECT — use isRedirect to distinguish intentional redirects from errors
+import { isRedirect } from '@tanstack/react-router'
+
+beforeLoad: async ({ context }) => {
+  try {
+    await validateSession(context.auth)
+  } catch (e) {
+    if (isRedirect(e)) throw e
+    console.error(e)
+  }
+}
+```
+
+### MEDIUM: Conditionally rendering root route component
+
+The root route always renders regardless of auth state. You cannot conditionally render its component:
+
+```tsx
+// WRONG — root route always renders, this doesn't protect anything
+export const Route = createRootRoute({
+  component: () => {
+    if (!isAuthenticated()) return <Login />
+    return <Outlet />
+  },
+})
+
+// CORRECT — use a pathless layout route for auth boundaries
+// src/routes/_authenticated.tsx
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({ to: '/login' })
+    }
+  },
+})
+```
+
+Place protected routes as children of the `_authenticated` layout route. Public routes (login, home, etc.) live outside it.
+
+---
+
+## Cross-References
+
+- See also: **router-core/data-loading/SKILL.md** — `beforeLoad` runs before `loader`; auth context flows into loader via route context

--- a/.agents/skills/tanstack-router-core-code-splitting/SKILL.md
+++ b/.agents/skills/tanstack-router-core-code-splitting/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   splitBehavior programmatic config, critical vs non-critical properties.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:
@@ -318,5 +318,5 @@ const data = routeApi.useLoaderData()
 
 ## Cross-References
 
-- **router-core/data-loading** — Loader splitting decisions affect data loading performance. Splitting the loader adds latency before data can be fetched.
-- **router-core/type-safety** — `getRouteApi` is the type-safe way to access hooks from split files.
+- **tanstack-router-core-data-loading** — Loader splitting decisions affect data loading performance. Splitting the loader adds latency before data can be fetched.
+- **tanstack-router-core-type-safety** — `getRouteApi` is the type-safe way to access hooks from split files.

--- a/.agents/skills/tanstack-router-core-code-splitting/SKILL.md
+++ b/.agents/skills/tanstack-router-core-code-splitting/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: tanstack-router-core-code-splitting
+description: >-
+  Automatic code splitting (autoCodeSplitting), .lazy.tsx convention,
+  createLazyFileRoute, createLazyRoute, lazyRouteComponent, getRouteApi
+  for typed hooks in split files, codeSplitGroupings per-route override,
+  splitBehavior programmatic config, critical vs non-critical properties.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/code-splitting.md
+  - TanStack/router:docs/router/guide/automatic-code-splitting.md
+---
+
+# Code Splitting
+
+TanStack Router separates route code into **critical** (required to match and start loading) and **non-critical** (can be lazy-loaded). The bundler plugin can split automatically, or you can split manually with `.lazy.tsx` files.
+
+> **CRITICAL**: Never `export` component functions from route files — exported functions are included in the main bundle and bypass code splitting entirely.
+
+> **CRITICAL**: Use `getRouteApi('/path')` in code-split files, NOT `import { Route } from './route'`. Importing Route defeats code splitting.
+
+## What Stays in the Main Bundle (Critical)
+
+- Path parsing/serialization
+- `validateSearch`
+- `loader`, `beforeLoad`
+- Route context, static data
+- Links, scripts, styles
+
+## What Gets Split (Non-Critical)
+
+- `component`
+- `errorComponent`
+- `pendingComponent`
+- `notFoundComponent`
+
+> The `loader` is NOT split by default. It is already async, so splitting it adds a double async cost: fetch the chunk, then execute the loader. Only split the loader if you have a specific reason.
+
+## Setup: Automatic Code Splitting
+
+Enable `autoCodeSplitting: true` in the bundler plugin. This is the recommended approach.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
+
+export default defineConfig({
+  plugins: [
+    // TanStack Router plugin MUST come before the framework plugin
+    tanstackRouter({
+      autoCodeSplitting: true,
+    }),
+    react(),
+  ],
+})
+```
+
+With this enabled, route files are automatically transformed. Components are split into separate chunks; loaders stay in the main bundle. No `.lazy.tsx` files needed.
+
+```tsx
+// src/routes/posts.tsx — everything in one file, splitting is automatic
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchPosts } from '../api'
+
+export const Route = createFileRoute('/posts')({
+  loader: fetchPosts,
+  component: PostsComponent,
+})
+
+// NOT exported — this is critical for automatic code splitting to work
+function PostsComponent() {
+  const posts = Route.useLoaderData()
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Manual Splitting with `.lazy.tsx`
+
+If you cannot use automatic code splitting (e.g. CLI-only, no bundler plugin), split manually into two files:
+
+```tsx
+// src/routes/posts.tsx — critical route config only
+import { createFileRoute } from '@tanstack/react-router'
+import { fetchPosts } from '../api'
+
+export const Route = createFileRoute('/posts')({
+  loader: fetchPosts,
+})
+```
+
+```tsx
+// src/routes/posts.lazy.tsx — non-critical (lazy-loaded)
+import { createLazyFileRoute } from '@tanstack/react-router'
+
+export const Route = createLazyFileRoute('/posts')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  // Use getRouteApi to access typed hooks without importing Route
+  return <div>Posts</div>
+}
+```
+
+`createLazyFileRoute` supports only: `component`, `errorComponent`, `pendingComponent`, `notFoundComponent`.
+
+## Virtual Routes
+
+If splitting leaves the critical route file empty, delete it entirely. A virtual route is auto-generated in `routeTree.gen.ts`:
+
+```tsx
+// src/routes/about.lazy.tsx — no about.tsx needed
+import { createLazyFileRoute } from '@tanstack/react-router'
+
+export const Route = createLazyFileRoute('/about')({
+  component: () => <h1>About Us</h1>,
+})
+```
+
+## Code-Based Splitting
+
+For code-based (non-file-based) routing, use `createLazyRoute` and the `.lazy()` method:
+
+```tsx
+// src/posts.lazy.tsx
+import { createLazyRoute } from '@tanstack/react-router'
+
+export const Route = createLazyRoute('/posts')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  return <div>Posts</div>
+}
+```
+
+```tsx
+// src/app.tsx
+import { createRoute } from '@tanstack/react-router'
+
+const postsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/posts',
+}).lazy(() => import('./posts.lazy').then((d) => d.Route))
+```
+
+## Accessing Typed Hooks in Split Files: `getRouteApi`
+
+When your component lives in a separate file, use `getRouteApi` to get typed access to route hooks without importing the Route object:
+
+```tsx
+// src/routes/posts.lazy.tsx
+import { createLazyFileRoute, getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/posts')
+
+export const Route = createLazyFileRoute('/posts')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const posts = routeApi.useLoaderData()
+  const { page } = routeApi.useSearch()
+  const params = routeApi.useParams()
+  const context = routeApi.useRouteContext()
+  return <div>Posts page {page}</div>
+}
+```
+
+`getRouteApi` provides: `useLoaderData`, `useLoaderDeps`, `useMatch`, `useParams`, `useRouteContext`, `useSearch`.
+
+## Per-Route Split Overrides: `codeSplitGroupings`
+
+Override split behavior for a specific route by adding `codeSplitGroupings` directly in the route file:
+
+```tsx
+// src/routes/posts.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { loadPostsData } from './-heavy-posts-utils'
+
+export const Route = createFileRoute('/posts')({
+  // Bundle loader and component together for this route
+  codeSplitGroupings: [['loader', 'component']],
+  loader: () => loadPostsData(),
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const data = Route.useLoaderData()
+  return <div>{data.title}</div>
+}
+```
+
+## Global Split Configuration
+
+### `defaultBehavior` — Change Default Groupings
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
+
+export default defineConfig({
+  plugins: [
+    tanstackRouter({
+      autoCodeSplitting: true,
+      codeSplittingOptions: {
+        defaultBehavior: [
+          // Bundle all UI components into one chunk
+          [
+            'component',
+            'pendingComponent',
+            'errorComponent',
+            'notFoundComponent',
+          ],
+        ],
+      },
+    }),
+  ],
+})
+```
+
+### `splitBehavior` — Programmatic Per-Route Logic
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
+
+export default defineConfig({
+  plugins: [
+    tanstackRouter({
+      autoCodeSplitting: true,
+      codeSplittingOptions: {
+        splitBehavior: ({ routeId }) => {
+          if (routeId.startsWith('/posts')) {
+            return [['loader', 'component']]
+          }
+          // All other routes use defaultBehavior
+        },
+      },
+    }),
+  ],
+})
+```
+
+### Precedence Order
+
+1. Per-route `codeSplitGroupings` (highest)
+2. `splitBehavior` function
+3. `defaultBehavior` option (lowest)
+
+## Common Mistakes
+
+### 1. HIGH: Exporting component functions prevents code splitting
+
+```tsx
+// WRONG — export puts PostsComponent in the main bundle
+export function PostsComponent() {
+  return <div>Posts</div>
+}
+
+// CORRECT — no export, function stays in the split chunk
+function PostsComponent() {
+  return <div>Posts</div>
+}
+```
+
+### 2. MEDIUM: Trying to code-split the root route
+
+`__root.tsx` does not support code splitting. It is always rendered regardless of the current route. Do not create `__root.lazy.tsx`.
+
+### 3. MEDIUM: Splitting the loader adds double async cost
+
+```tsx
+// AVOID unless you have a specific reason
+codeSplittingOptions: {
+  defaultBehavior: [
+    ['loader'], // Fetch chunk THEN execute loader = two network waterfalls
+    ['component'],
+  ],
+}
+
+// PREFERRED — loader stays in main bundle (default behavior)
+codeSplittingOptions: {
+  defaultBehavior: [
+    ['component'],
+    ['errorComponent'],
+    ['notFoundComponent'],
+  ],
+}
+```
+
+### 4. HIGH: Importing Route in code-split files for typed hooks
+
+```tsx
+// WRONG — importing Route pulls route config into the lazy chunk
+import { Route } from './posts.tsx'
+const data = Route.useLoaderData()
+
+// CORRECT — getRouteApi gives typed hooks without pulling in the route
+import { getRouteApi } from '@tanstack/react-router'
+const routeApi = getRouteApi('/posts')
+const data = routeApi.useLoaderData()
+```
+
+## Cross-References
+
+- **router-core/data-loading** — Loader splitting decisions affect data loading performance. Splitting the loader adds latency before data can be fetched.
+- **router-core/type-safety** — `getRouteApi` is the type-safe way to access hooks from split files.

--- a/.agents/skills/tanstack-router-core-code-splitting/SKILL.md
+++ b/.agents/skills/tanstack-router-core-code-splitting/SKILL.md
@@ -9,7 +9,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/code-splitting.md
   - TanStack/router:docs/router/guide/automatic-code-splitting.md

--- a/.agents/skills/tanstack-router-core-data-loading/SKILL.md
+++ b/.agents/skills/tanstack-router-core-data-loading/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: tanstack-router-core-data-loading
+description: >-
+  Route loader option, loaderDeps for cache keys, staleTime/gcTime/
+  defaultPreloadStaleTime SWR caching, pendingComponent/pendingMs/
+  pendingMinMs, errorComponent/onError/onCatch, beforeLoad, router
+  context and createRootRouteWithContext DI pattern, router.invalidate,
+  Await component, deferred data loading with unawaited promises.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/data-loading.md
+  - TanStack/router:docs/router/guide/deferred-data-loading.md
+  - TanStack/router:docs/router/guide/router-context.md
+  - TanStack/router:docs/router/guide/data-mutations.md
+---
+
+# Data Loading
+
+## Setup
+
+Basic loader returning data, consumed via `useLoaderData`:
+
+```tsx
+// src/routes/posts.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const posts = Route.useLoaderData()
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+In code-split components, use `getRouteApi` instead of importing Route:
+
+```tsx
+import { getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/posts')
+
+function PostsComponent() {
+  const posts = routeApi.useLoaderData()
+  return <ul>{/* ... */}</ul>
+}
+```
+
+## Route Loading Lifecycle
+
+The router executes this sequence on every URL/history update:
+
+1. **Route Matching** (top-down)
+   - `route.params.parse`
+   - `route.validateSearch`
+2. **Route Pre-Loading** (serial)
+   - `route.beforeLoad`
+   - `route.onError` → `route.errorComponent`
+3. **Route Loading** (parallel)
+   - `route.component.preload?`
+   - `route.loader`
+     - `route.pendingComponent` (optional)
+     - `route.component`
+   - `route.onError` → `route.errorComponent`
+
+Key: `beforeLoad` runs before `loader`. `beforeLoad` for a parent runs before its children's `beforeLoad`. Throwing in `beforeLoad` prevents all children from loading.
+
+## Core Patterns
+
+### loaderDeps for Search-Param-Driven Cache Keys
+
+Loaders don't receive search params directly. Use `loaderDeps` to declare which search params affect the cache key:
+
+```tsx
+// src/routes/posts.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts')({
+  validateSearch: (search) => ({
+    offset: Number(search.offset) || 0,
+    limit: Number(search.limit) || 10,
+  }),
+  loaderDeps: ({ search: { offset, limit } }) => ({ offset, limit }),
+  loader: ({ deps: { offset, limit } }) => fetchPosts({ offset, limit }),
+})
+```
+
+When deps change, the route reloads regardless of `staleTime`.
+
+### SWR Caching Configuration
+
+TanStack Router has built-in Stale-While-Revalidate caching keyed on the route's parsed pathname + `loaderDeps`.
+
+Defaults:
+
+- **`staleTime`: 0** — data is always considered stale, reloads in background on re-match
+- **`preloadStaleTime`: 30 seconds** — preloaded data won't be refetched for 30s
+- **`gcTime`: 30 minutes** — unused cache entries garbage collected after 30min
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  staleTime: 10_000, // 10s: data considered fresh for 10 seconds
+  gcTime: 5 * 60 * 1000, // 5min: garbage collect after 5 minutes
+})
+```
+
+Disable SWR caching entirely:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  staleTime: Infinity,
+})
+```
+
+Globally:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  defaultStaleTime: Infinity,
+})
+```
+
+### Pending States (pendingComponent / pendingMs / pendingMinMs)
+
+By default, a pending component shows after 1 second (`pendingMs: 1000`) and stays for at least 500ms (`pendingMinMs: 500`) to avoid flash.
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  pendingMs: 500,
+  pendingMinMs: 300,
+  pendingComponent: () => <div>Loading posts...</div>,
+  component: PostsComponent,
+})
+```
+
+### Router Context with createRootRouteWithContext (Factory Pattern)
+
+`createRootRouteWithContext` is a factory that returns a function. You must call it twice — the first call passes the generic type, the second passes route options:
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+
+interface MyRouterContext {
+  auth: { userId: string }
+  fetchPosts: () => Promise<Post[]>
+}
+
+// NOTE: double call — createRootRouteWithContext<Type>()({...})
+export const Route = createRootRouteWithContext<MyRouterContext>()({
+  component: () => <Outlet />,
+})
+```
+
+Supply the context when creating the router:
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({
+  routeTree,
+  context: {
+    auth: { userId: '123' },
+    fetchPosts,
+  },
+})
+```
+
+Consume in loaders and beforeLoad:
+
+```tsx
+// src/routes/posts.tsx
+export const Route = createFileRoute('/posts')({
+  loader: ({ context: { fetchPosts } }) => fetchPosts(),
+})
+```
+
+To pass React hook values into the router context, call the hook above `RouterProvider` and inject via the `context` prop:
+
+```tsx
+import { RouterProvider } from '@tanstack/react-router'
+
+function InnerApp() {
+  const auth = useAuth()
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <InnerApp />
+    </AuthProvider>
+  )
+}
+```
+
+Route-level context via `beforeLoad`:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  beforeLoad: () => ({
+    fetchPosts: () => fetch('/api/posts').then((r) => r.json()),
+  }),
+  loader: ({ context: { fetchPosts } }) => fetchPosts(),
+})
+```
+
+### Deferred Data Loading
+
+Return unawaited promises from the loader for non-critical data. Use the `Await` component to render them:
+
+```tsx
+import { createFileRoute, Await } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    // Slow data — do NOT await
+    const slowDataPromise = fetchComments(postId)
+    // Fast data — await
+    const post = await fetchPost(postId)
+
+    return { post, deferredComments: slowDataPromise }
+  },
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { post, deferredComments } = Route.useLoaderData()
+
+  return (
+    <div>
+      <h1>{post.title}</h1>
+      <Await
+        promise={deferredComments}
+        fallback={<div>Loading comments...</div>}
+      >
+        {(comments) => (
+          <ul>
+            {comments.map((c) => (
+              <li key={c.id}>{c.body}</li>
+            ))}
+          </ul>
+        )}
+      </Await>
+    </div>
+  )
+}
+```
+
+### Invalidation After Mutations
+
+`router.invalidate()` forces all active route loaders to re-run and marks all cached data as stale:
+
+```tsx
+import { useRouter } from '@tanstack/react-router'
+
+function AddPostButton() {
+  const router = useRouter()
+
+  const handleAdd = async () => {
+    await fetch('/api/posts', { method: 'POST', body: '...' })
+    router.invalidate()
+  }
+
+  return <button onClick={handleAdd}>Add Post</button>
+}
+```
+
+For synchronous invalidation (wait until loaders finish):
+
+```tsx
+await router.invalidate({ sync: true })
+```
+
+### Error Handling
+
+```tsx
+import {
+  createFileRoute,
+  ErrorComponent,
+  useRouter,
+} from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  errorComponent: ({ error, reset }) => {
+    const router = useRouter()
+
+    if (error instanceof CustomError) {
+      return <div>{error.message}</div>
+    }
+
+    return (
+      <div>
+        <ErrorComponent error={error} />
+        <button
+          onClick={() => {
+            // For loader errors, invalidate to re-run loader + reset boundary
+            router.invalidate()
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  },
+})
+```
+
+### Loader Parameters
+
+The `loader` function receives:
+
+- `params` — parsed path params
+- `deps` — object from `loaderDeps`
+- `context` — merged parent + beforeLoad context
+- `abortController` — cancelled when route unloads or becomes stale
+- `cause` — `'enter'`, `'stay'`, or `'preload'`
+- `preload` — `true` during preloading
+- `location` — current location object
+- `parentMatchPromise` — promise of parent route match
+- `route` — the route object itself
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  loader: ({ params: { postId }, abortController }) =>
+    fetchPost(postId, { signal: abortController.signal }),
+})
+```
+
+## Common Mistakes
+
+### CRITICAL: Assuming loaders only run on the server
+
+TanStack Router is **client-first**. Loaders run on the **client** by default. They also run on the server when using TanStack Start for SSR, but the default mental model is client-side execution.
+
+```tsx
+// WRONG — this will crash in the browser
+export const Route = createFileRoute('/posts')({
+  loader: async () => {
+    const fs = await import('fs') // Node.js only!
+    return JSON.parse(fs.readFileSync('...')) // fails in browser
+  },
+})
+
+// CORRECT — loaders run in the browser, use fetch or API calls
+export const Route = createFileRoute('/posts')({
+  loader: async () => {
+    const res = await fetch('/api/posts')
+    return res.json()
+  },
+})
+```
+
+Do NOT put database queries, filesystem access, or server-only code in loaders unless you are using TanStack Start server functions.
+
+### MEDIUM: Not understanding staleTime default is 0
+
+Default `staleTime` is `0`. This means data reloads in the background on every route re-match. This is intentional — it ensures fresh data. But if your data is expensive or static, set `staleTime`:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  staleTime: 60_000, // Consider fresh for 1 minute
+})
+```
+
+### HIGH: Using reset() instead of router.invalidate() in error components
+
+`reset()` only resets the error boundary UI. It does NOT re-run the loader. For loader errors, use `router.invalidate()` which re-runs loaders and resets the boundary:
+
+```tsx
+// WRONG — resets boundary but loader still has stale error
+function PostErrorComponent({ error, reset }) {
+  return <button onClick={reset}>Retry</button>
+}
+
+// CORRECT — re-runs loader and resets the error boundary
+function PostErrorComponent({ error }) {
+  const router = useRouter()
+  return <button onClick={() => router.invalidate()}>Retry</button>
+}
+```
+
+### HIGH: Missing double parentheses on createRootRouteWithContext
+
+`createRootRouteWithContext<Type>()` is a factory — it returns a function. Must call twice:
+
+```tsx
+// WRONG — missing second call, passes options to the factory
+const rootRoute = createRootRouteWithContext<{ auth: AuthState }>({
+  component: RootComponent,
+})
+
+// CORRECT — factory()({options})
+const rootRoute = createRootRouteWithContext<{ auth: AuthState }>()({
+  component: RootComponent,
+})
+```
+
+### HIGH: Using React hooks in beforeLoad or loader
+
+`beforeLoad` and `loader` are NOT React components. You cannot call hooks inside them. Use router context to inject values from hooks:
+
+```tsx
+// WRONG — hooks cannot be called outside React components
+export const Route = createFileRoute('/posts')({
+  loader: () => {
+    const auth = useAuth() // This will crash!
+    return fetchPosts(auth.userId)
+  },
+})
+
+// CORRECT — inject hook values via router context
+// In your App component:
+function InnerApp() {
+  const auth = useAuth()
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+// In your route:
+export const Route = createFileRoute('/posts')({
+  loader: ({ context: { auth } }) => fetchPosts(auth.userId),
+})
+```
+
+### HIGH: Property order affects TypeScript inference
+
+Router infers types from earlier properties into later ones. Declaring `beforeLoad` after `loader` means context from `beforeLoad` is unknown in the loader:
+
+```tsx
+// WRONG — context.user is unknown because beforeLoad declared after loader
+export const Route = createFileRoute('/admin')({
+  loader: ({ context }) => fetchData(context.user),
+  beforeLoad: () => ({ user: getUser() }),
+})
+
+// CORRECT — validateSearch → loaderDeps → beforeLoad → loader
+export const Route = createFileRoute('/admin')({
+  beforeLoad: () => ({ user: getUser() }),
+  loader: ({ context }) => fetchData(context.user),
+})
+```
+
+### HIGH: Returning entire search object from loaderDeps
+
+```tsx
+// WRONG — loader re-runs on ANY search param change
+loaderDeps: ({ search }) => search
+
+// CORRECT — only re-run when page changes
+loaderDeps: ({ search }) => ({ page: search.page })
+```
+
+Returning the whole `search` object means unrelated param changes (e.g., `sortDirection`, `viewMode`) trigger unnecessary reloads because deep equality fails on the entire object.
+
+## Tensions
+
+- **Client-first loaders vs SSR expectations**: Loaders run on the client by default. When using SSR (TanStack Start), they run on both client and server. Browser-only APIs work by default but break under SSR. Server-only APIs (fs, db) break by default but work under Start server functions. See **router-core/ssr/SKILL.md**.
+- **Built-in SWR cache vs external cache coordination**: Router has built-in caching. When using TanStack Query, set `defaultPreloadStaleTime: 0` to avoid double-caching. See **compositions/router-query/SKILL.md**.
+
+---
+
+## Cross-References
+
+- See also: **router-core/search-params/SKILL.md** — `loaderDeps` consumes validated search params as cache keys
+- See also: **compositions/router-query/SKILL.md** — for external cache coordination with TanStack Query

--- a/.agents/skills/tanstack-router-core-data-loading/SKILL.md
+++ b/.agents/skills/tanstack-router-core-data-loading/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   Await component, deferred data loading with unawaited promises.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:
@@ -474,12 +474,12 @@ Returning the whole `search` object means unrelated param changes (e.g., `sortDi
 
 ## Tensions
 
-- **Client-first loaders vs SSR expectations**: Loaders run on the client by default. When using SSR (TanStack Start), they run on both client and server. Browser-only APIs work by default but break under SSR. Server-only APIs (fs, db) break by default but work under Start server functions. See **router-core/ssr/SKILL.md**.
+- **Client-first loaders vs SSR expectations**: Loaders run on the client by default. When using SSR (TanStack Start), they run on both client and server. Browser-only APIs work by default but break under SSR. Server-only APIs (fs, db) break by default but work under Start server functions. See **tanstack-router-core-ssr/SKILL.md**.
 - **Built-in SWR cache vs external cache coordination**: Router has built-in caching. When using TanStack Query, set `defaultPreloadStaleTime: 0` to avoid double-caching. See **compositions/router-query/SKILL.md**.
 
 ---
 
 ## Cross-References
 
-- See also: **router-core/search-params/SKILL.md** — `loaderDeps` consumes validated search params as cache keys
+- See also: **tanstack-router-core-search-params/SKILL.md** — `loaderDeps` consumes validated search params as cache keys
 - See also: **compositions/router-query/SKILL.md** — for external cache coordination with TanStack Query

--- a/.agents/skills/tanstack-router-core-data-loading/SKILL.md
+++ b/.agents/skills/tanstack-router-core-data-loading/SKILL.md
@@ -10,7 +10,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/data-loading.md
   - TanStack/router:docs/router/guide/deferred-data-loading.md

--- a/.agents/skills/tanstack-router-core-navigation/SKILL.md
+++ b/.agents/skills/tanstack-router-core-navigation/SKILL.md
@@ -10,7 +10,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/navigation.md
   - TanStack/router:docs/router/guide/preloading.md

--- a/.agents/skills/tanstack-router-core-navigation/SKILL.md
+++ b/.agents/skills/tanstack-router-core-navigation/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: tanstack-router-core-navigation
+description: >-
+  Link component, useNavigate, Navigate component, router.navigate,
+  ToOptions/NavigateOptions/LinkOptions, from/to relative navigation,
+  activeOptions/activeProps, preloading (intent/viewport/render),
+  preloadDelay, navigation blocking (useBlocker, Block), createLink,
+  linkOptions helper, scroll restoration, MatchRoute.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/navigation.md
+  - TanStack/router:docs/router/guide/preloading.md
+  - TanStack/router:docs/router/guide/navigation-blocking.md
+  - TanStack/router:docs/router/guide/link-options.md
+  - TanStack/router:docs/router/guide/custom-link.md
+  - TanStack/router:docs/router/guide/scroll-restoration.md
+---
+
+# Navigation
+
+## Setup
+
+Basic type-safe `Link` with `to` and `params`:
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function PostLink({ postId }: { postId: string }) {
+  return (
+    <Link to="/posts/$postId" params={{ postId }}>
+      View Post
+    </Link>
+  )
+}
+```
+
+## Core Patterns
+
+### Link with Active States
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function NavLink() {
+  return (
+    <Link
+      to="/posts"
+      activeProps={{ className: 'font-bold' }}
+      inactiveProps={{ className: 'text-gray-500' }}
+      activeOptions={{ exact: true }}
+    >
+      Posts
+    </Link>
+  )
+}
+```
+
+The `data-status` attribute is also set to `"active"` on active links for CSS-based styling.
+
+`activeOptions` controls matching behavior:
+
+- `exact` (default `false`) — when `true`, only matches the exact path (not children)
+- `includeHash` (default `false`) — include hash in active matching
+- `includeSearch` (default `true`) — include search params in active matching
+
+Children can receive `isActive` as a render function:
+
+```tsx
+<Link to="/posts">
+  {({ isActive }) => <span className={isActive ? 'font-bold' : ''}>Posts</span>}
+</Link>
+```
+
+### Relative Navigation with `from`
+
+Without `from`, navigation resolves from root `/`. To use relative paths like `..`, provide `from`:
+
+```tsx
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  component: PostComponent,
+})
+
+function PostComponent() {
+  return (
+    <div>
+      {/* Relative to current route */}
+      <Link from={Route.fullPath} to="..">
+        Back to Posts
+      </Link>
+
+      {/* "." reloads the current route */}
+      <Link from={Route.fullPath} to=".">
+        Reload
+      </Link>
+    </div>
+  )
+}
+```
+
+### useNavigate for Programmatic Navigation
+
+Use `useNavigate` only for side-effect-driven navigation (e.g., after a form submission). For anything the user clicks, prefer `Link`.
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function CreatePostForm() {
+  const navigate = useNavigate({ from: '/posts' })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const response = await fetch('/api/posts', { method: 'POST', body: '...' })
+    const { id: postId } = await response.json()
+
+    if (response.ok) {
+      navigate({ to: '/posts/$postId', params: { postId } })
+    }
+  }
+
+  return <form onSubmit={handleSubmit}>{/* ... */}</form>
+}
+```
+
+The `Navigate` component performs an immediate client-side navigation on mount:
+
+```tsx
+import { Navigate } from '@tanstack/react-router'
+
+function LegacyRedirect() {
+  return <Navigate to="/posts/$postId" params={{ postId: 'my-first-post' }} />
+}
+```
+
+`router.navigate` is available anywhere you have the router instance, including outside of React.
+
+### Preloading
+
+Strategies: `intent` (hover/touchstart), `viewport` (intersection observer), `render` (on mount).
+
+Set globally:
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: 'intent',
+  defaultPreloadDelay: 50, // ms, default is 50
+})
+```
+
+Or per-link:
+
+```tsx
+<Link
+  to="/posts/$postId"
+  params={{ postId }}
+  preload="intent"
+  preloadDelay={100}
+>
+  View Post
+</Link>
+```
+
+Preloaded data stays fresh for 30 seconds by default (`defaultPreloadStaleTime: 30_000`). During that window it won't be refetched. When using an external cache like TanStack Query, set `defaultPreloadStaleTime: 0` to let the external library control freshness.
+
+Manual preloading via the router instance:
+
+```tsx
+import { useRouter } from '@tanstack/react-router'
+
+function Component() {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.preloadRoute({ to: '/posts/$postId', params: { postId: '1' } })
+  }, [router])
+
+  return <div />
+}
+```
+
+### Navigation Blocking
+
+Use `useBlocker` to prevent navigation when a form has unsaved changes:
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+import { useState } from 'react'
+
+function EditForm() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  useBlocker({
+    shouldBlockFn: () => {
+      if (!formIsDirty) return false
+      const shouldLeave = confirm('Are you sure you want to leave?')
+      return !shouldLeave
+    },
+  })
+
+  return <form>{/* ... */}</form>
+}
+```
+
+With custom UI using `withResolver`:
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+import { useState } from 'react'
+
+function EditForm() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  const { proceed, reset, status } = useBlocker({
+    shouldBlockFn: () => formIsDirty,
+    withResolver: true,
+  })
+
+  return (
+    <>
+      <form>{/* ... */}</form>
+      {status === 'blocked' && (
+        <div>
+          <p>Are you sure you want to leave?</p>
+          <button onClick={proceed}>Yes</button>
+          <button onClick={reset}>No</button>
+        </div>
+      )}
+    </>
+  )
+}
+```
+
+Control `beforeunload` separately:
+
+```tsx
+useBlocker({
+  shouldBlockFn: () => formIsDirty,
+  enableBeforeUnload: formIsDirty,
+})
+```
+
+### linkOptions for Reusable Navigation Options
+
+`linkOptions` provides eager type-checking on navigation options objects, so errors surface at definition, not at spread-site:
+
+```tsx
+import {
+  linkOptions,
+  Link,
+  useNavigate,
+  redirect,
+} from '@tanstack/react-router'
+
+const dashboardLinkOptions = linkOptions({
+  to: '/dashboard',
+  search: { search: '' },
+})
+
+// Use anywhere: Link, navigate, redirect
+function Nav() {
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <Link {...dashboardLinkOptions}>Dashboard</Link>
+      <button onClick={() => navigate(dashboardLinkOptions)}>Go</button>
+    </div>
+  )
+}
+
+// Also works in an array for navigation bars
+const navOptions = linkOptions([
+  { to: '/dashboard', label: 'Summary', activeOptions: { exact: true } },
+  { to: '/dashboard/invoices', label: 'Invoices' },
+  { to: '/dashboard/users', label: 'Users' },
+])
+
+function NavBar() {
+  return (
+    <nav>
+      {navOptions.map((option) => (
+        <Link
+          {...option}
+          key={option.to}
+          activeProps={{ className: 'font-bold' }}
+        >
+          {option.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}
+```
+
+### createLink for Custom Components
+
+Wraps any component with TanStack Router's type-safe navigation:
+
+```tsx
+import * as React from 'react'
+import { createLink, LinkComponent } from '@tanstack/react-router'
+
+interface BasicLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {}
+
+const BasicLinkComponent = React.forwardRef<HTMLAnchorElement, BasicLinkProps>(
+  (props, ref) => {
+    return <a ref={ref} {...props} className="block px-3 py-2 text-blue-700" />
+  },
+)
+
+const CreatedLinkComponent = createLink(BasicLinkComponent)
+
+export const CustomLink: LinkComponent<typeof BasicLinkComponent> = (props) => {
+  return <CreatedLinkComponent preload="intent" {...props} />
+}
+```
+
+Usage retains full type safety:
+
+```tsx
+<CustomLink to="/dashboard/invoices/$invoiceId" params={{ invoiceId: 0 }} />
+```
+
+### Scroll Restoration
+
+Enable globally on the router:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  scrollRestoration: true,
+})
+```
+
+For nested scrollable areas:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  scrollRestoration: true,
+  scrollToTopSelectors: ['#main-scrollable-area'],
+})
+```
+
+Custom cache keys:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  scrollRestoration: true,
+  getScrollRestorationKey: (location) => location.pathname,
+})
+```
+
+Prevent scroll reset for a specific navigation:
+
+```tsx
+<Link to="/posts" resetScroll={false}>
+  Posts
+</Link>
+```
+
+### MatchRoute for Pending UI
+
+```tsx
+import { Link, MatchRoute } from '@tanstack/react-router'
+
+function Nav() {
+  return (
+    <Link to="/users">
+      Users
+      <MatchRoute to="/users" pending>
+        <Spinner />
+      </MatchRoute>
+    </Link>
+  )
+}
+```
+
+## Common Mistakes
+
+### CRITICAL: Interpolating params into the `to` string
+
+```tsx
+// WRONG — breaks type safety and param encoding
+<Link to={`/posts/${postId}`}>Post</Link>
+
+// CORRECT — use the params option
+<Link to="/posts/$postId" params={{ postId }}>Post</Link>
+```
+
+Dynamic segments are declared with `$` in the route path. Always pass them via `params`. This applies to `Link`, `useNavigate`, `Navigate`, and `router.navigate`.
+
+### MEDIUM: Using useNavigate for clickable elements
+
+```tsx
+// WRONG — no href, no cmd+click, no preloading, no accessibility
+function BadNav() {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate({ to: '/posts' })}>Posts</button>
+}
+
+// CORRECT — real <a> tag with href, accessible, preloadable
+function GoodNav() {
+  return <Link to="/posts">Posts</Link>
+}
+```
+
+Use `useNavigate` only for programmatic side-effect navigation (after form submit, async action, etc).
+
+### HIGH: Not providing `from` for relative navigation
+
+```tsx
+// WRONG — without from, ".." resolves from root
+<Link to="..">Back</Link>
+
+// CORRECT — provide from for relative resolution
+<Link from={Route.fullPath} to="..">Back</Link>
+```
+
+Without `from`, only absolute paths are autocompleted and type-safe. Relative paths like `..` resolve from root instead of the current route.
+
+### HIGH: Using search as object instead of function loses existing params
+
+```tsx
+// WRONG — replaces ALL search params with just { page: 2 }
+<Link to="." search={{ page: 2 }}>Page 2</Link>
+
+// CORRECT — preserves existing search params, updates page
+<Link to="." search={(prev) => ({ ...prev, page: 2 })}>Page 2</Link>
+```
+
+When you pass `search` as a plain object, it replaces all search params. Use the function form to spread previous params and selectively update.
+
+---
+
+## Cross-References
+
+- See also: **router-core/search-params/SKILL.md** — Link `search` prop interacts with search param validation
+- See also: **router-core/type-safety/SKILL.md** — `from` narrowing improves type inference on Link

--- a/.agents/skills/tanstack-router-core-navigation/SKILL.md
+++ b/.agents/skills/tanstack-router-core-navigation/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   linkOptions helper, scroll restoration, MatchRoute.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:
@@ -444,5 +444,5 @@ When you pass `search` as a plain object, it replaces all search params. Use the
 
 ## Cross-References
 
-- See also: **router-core/search-params/SKILL.md** — Link `search` prop interacts with search param validation
-- See also: **router-core/type-safety/SKILL.md** — `from` narrowing improves type inference on Link
+- See also: **tanstack-router-core-search-params/SKILL.md** — Link `search` prop interacts with search param validation
+- See also: **tanstack-router-core-type-safety/SKILL.md** — `from` narrowing improves type inference on Link

--- a/.agents/skills/tanstack-router-core-not-found-and-errors/SKILL.md
+++ b/.agents/skills/tanstack-router-core-not-found-and-errors/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: tanstack-router-core-not-found-and-errors
+description: >-
+  notFound() function, notFoundComponent, defaultNotFoundComponent,
+  notFoundMode (fuzzy/root), errorComponent, CatchBoundary,
+  CatchNotFound, isNotFound, NotFoundRoute (deprecated), route
+  masking (mask option, createRouteMask, unmaskOnReload).
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/not-found-errors.md
+  - TanStack/router:docs/router/guide/route-masking.md
+---
+
+# Not Found and Errors
+
+TanStack Router handles two categories of "not found": unmatched URL paths (automatic) and missing resources like a post that doesn't exist (manual via `notFound()`). Error boundaries are configured per-route via `errorComponent`.
+
+> **CRITICAL**: Do NOT use the deprecated `NotFoundRoute`. When present, `notFound()` and `notFoundComponent` will NOT work. Remove it and use `notFoundComponent` instead.
+> **CRITICAL**: `useLoaderData` may be undefined inside `notFoundComponent`. Use `useParams`, `useSearch`, or `useRouteContext` instead.
+
+## Not Found Handling
+
+### Global 404: `notFoundComponent` on Root Route
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRoute, Outlet, Link } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+  notFoundComponent: () => {
+    return (
+      <div>
+        <h1>404 — Page Not Found</h1>
+        <Link to="/">Go Home</Link>
+      </div>
+    )
+  },
+})
+```
+
+### Router-Wide Default: `defaultNotFoundComponent`
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({
+  routeTree,
+  defaultNotFoundComponent: () => {
+    return (
+      <div>
+        <p>Not found!</p>
+        <Link to="/">Go home</Link>
+      </div>
+    )
+  },
+})
+```
+
+### Per-Route 404: Missing Resources with `notFound()`
+
+Throw `notFound()` in `loader` or `beforeLoad` when a resource doesn't exist. It works like `redirect()` — throw it to trigger the not-found boundary.
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { getPost } from '../api'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const post = await getPost(postId)
+    if (!post) throw notFound()
+    return { post }
+  },
+  component: PostComponent,
+  notFoundComponent: ({ data }) => {
+    const { postId } = Route.useParams()
+    return <p>Post "{postId}" not found</p>
+  },
+})
+
+function PostComponent() {
+  const { post } = Route.useLoaderData()
+  return <h1>{post.title}</h1>
+}
+```
+
+### Targeting a Specific Route with `notFound({ routeId })`
+
+You can force a specific parent route to handle the not-found error:
+
+```tsx
+// src/routes/_layout/posts.$postId.tsx
+import { createFileRoute, notFound } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_layout/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const post = await getPost(postId)
+    if (!post) throw notFound({ routeId: '/_layout' })
+    return { post }
+  },
+})
+```
+
+### Targeting Root Route with `rootRouteId`
+
+```tsx
+import { createFileRoute, notFound, rootRouteId } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const post = await getPost(postId)
+    if (!post) throw notFound({ routeId: rootRouteId })
+    return { post }
+  },
+})
+```
+
+## `notFoundMode`: Fuzzy vs Root
+
+### `fuzzy` (default)
+
+The router finds the nearest parent route with children and a `notFoundComponent`. Preserves as much parent layout as possible.
+
+Given routes: `__root__` → `posts` → `$postId`, accessing `/posts/1/edit`:
+
+- `<Root>` renders
+- `<Posts>` renders
+- `<Posts.notFoundComponent>` renders (nearest parent with children + notFoundComponent)
+
+### `root`
+
+All not-found errors go to the root route's `notFoundComponent`, regardless of matching:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  notFoundMode: 'root',
+})
+```
+
+## Error Handling
+
+### `errorComponent` Per Route
+
+`errorComponent` receives `error`, `info`, and `reset` props. For loader errors, use `router.invalidate()` to re-run the loader — it automatically resets the error boundary.
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute, useRouter } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const res = await fetch(`/api/posts/${postId}`)
+    if (!res.ok) throw new Error('Failed to load post')
+    return res.json()
+  },
+  component: PostComponent,
+  errorComponent: PostErrorComponent,
+})
+
+function PostErrorComponent({
+  error,
+}: {
+  error: Error
+  info: { componentStack: string }
+  reset: () => void
+}) {
+  const router = useRouter()
+
+  return (
+    <div>
+      <p>Error: {error.message}</p>
+      <button
+        onClick={() => {
+          // Invalidate re-runs the loader and resets the error boundary
+          router.invalidate()
+        }}
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+function PostComponent() {
+  const data = Route.useLoaderData()
+  return <h1>{data.title}</h1>
+}
+```
+
+### Router-Wide Default Error Component
+
+```tsx
+const router = createRouter({
+  routeTree,
+  defaultErrorComponent: ({ error }) => {
+    const router = useRouter()
+    return (
+      <div>
+        <p>Something went wrong: {error.message}</p>
+        <button
+          onClick={() => {
+            router.invalidate()
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  },
+})
+```
+
+## Data in `notFoundComponent`
+
+`notFoundComponent` cannot reliably use `useLoaderData` because the loader may not have completed. Safe hooks:
+
+```tsx
+notFoundComponent: ({ data }) => {
+  // SAFE — always available:
+  const params = Route.useParams()
+  const search = Route.useSearch()
+  const context = Route.useRouteContext()
+
+  // UNSAFE — may be undefined:
+  // const loaderData = Route.useLoaderData()
+
+  return <p>Item {params.id} not found</p>
+}
+```
+
+To forward partial data, use the `data` option on `notFound()`:
+
+```tsx
+loader: async ({ params }) => {
+  const partialData = await getPartialData(params.id)
+  if (!partialData.fullResource) {
+    throw notFound({ data: { name: partialData.name } })
+  }
+  return partialData
+},
+notFoundComponent: ({ data }) => {
+  // data is typed as unknown — validate it
+  const info = data as { name: string } | undefined
+  return <p>{info?.name ?? 'Resource'} not found</p>
+},
+```
+
+## Route Masking
+
+Route masking shows a different URL in the browser bar than the actual route being rendered. Masking data is stored in `location.state` and is lost when the URL is shared or opened in a new tab.
+
+### Imperative Masking on `<Link>`
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function PhotoGrid({ photoId }: { photoId: string }) {
+  return (
+    <Link
+      to="/photos/$photoId/modal"
+      params={{ photoId }}
+      mask={{
+        to: '/photos/$photoId',
+        params: { photoId },
+      }}
+    >
+      Open Photo
+    </Link>
+  )
+}
+```
+
+### Imperative Masking with `useNavigate`
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function OpenPhotoButton({ photoId }: { photoId: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <button
+      onClick={() =>
+        navigate({
+          to: '/photos/$photoId/modal',
+          params: { photoId },
+          mask: {
+            to: '/photos/$photoId',
+            params: { photoId },
+          },
+        })
+      }
+    >
+      Open Photo
+    </button>
+  )
+}
+```
+
+### Declarative Masking with `createRouteMask`
+
+```tsx
+import { createRouter, createRouteMask } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const photoModalMask = createRouteMask({
+  routeTree,
+  from: '/photos/$photoId/modal',
+  to: '/photos/$photoId',
+  params: (prev) => ({ photoId: prev.photoId }),
+})
+
+const router = createRouter({
+  routeTree,
+  routeMasks: [photoModalMask],
+})
+```
+
+### Unmasking on Reload
+
+By default, masks survive local page reloads. To unmask on reload:
+
+```tsx
+// Per-mask
+const mask = createRouteMask({
+  routeTree,
+  from: '/photos/$photoId/modal',
+  to: '/photos/$photoId',
+  params: (prev) => ({ photoId: prev.photoId }),
+  unmaskOnReload: true,
+})
+
+// Per-link
+<Link
+  to="/photos/$photoId/modal"
+  params={{ photoId }}
+  mask={{ to: '/photos/$photoId', params: { photoId } }}
+  unmaskOnReload
+>
+  Open Photo
+</Link>
+
+// Router-wide default
+const router = createRouter({
+  routeTree,
+  unmaskOnReload: true,
+})
+```
+
+## Common Mistakes
+
+### 1. HIGH: Using deprecated `NotFoundRoute`
+
+```tsx
+// WRONG — NotFoundRoute blocks notFound() and notFoundComponent from working
+import { NotFoundRoute } from '@tanstack/react-router'
+const notFoundRoute = new NotFoundRoute({ component: () => <p>404</p> })
+const router = createRouter({ routeTree, notFoundRoute })
+
+// CORRECT — use notFoundComponent on root route
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+  notFoundComponent: () => <p>404</p>,
+})
+```
+
+### 2. MEDIUM: Expecting `useLoaderData` in `notFoundComponent`
+
+```tsx
+// WRONG — loader may not have completed
+notFoundComponent: () => {
+  const data = Route.useLoaderData() // may be undefined!
+  return <p>{data.title} not found</p>
+}
+
+// CORRECT — use safe hooks
+notFoundComponent: () => {
+  const { postId } = Route.useParams()
+  return <p>Post {postId} not found</p>
+}
+```
+
+### 3. MEDIUM: Leaf routes cannot handle not-found errors
+
+Only routes with children (and therefore an `<Outlet>`) can render `notFoundComponent`. Leaf routes (routes without children) will never catch not-found errors — the error bubbles up to the nearest parent with children.
+
+```tsx
+// This route has NO children — notFoundComponent here will not catch
+// unmatched child paths (there are no child paths to unmatch)
+export const Route = createFileRoute('/posts/$postId')({
+  // notFoundComponent here only works for notFound() thrown in THIS route's loader
+  // It does NOT catch path-based not-founds
+  notFoundComponent: () => <p>Not found</p>,
+})
+```
+
+### 4. MEDIUM: Expecting masked URLs to survive sharing
+
+Masking data lives in `location.state` (browser history). When a masked URL is copied, shared, or opened in a new tab, the masking data is lost. The browser navigates to the visible (masked) URL directly.
+
+### 5. HIGH (cross-skill): Using `reset()` alone instead of `router.invalidate()`
+
+```tsx
+// WRONG — reset() clears the error boundary but does NOT re-run the loader
+function ErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return <button onClick={reset}>Retry</button>
+}
+
+// CORRECT — invalidate re-runs loaders and resets the error boundary
+function ErrorFallback({ error }: { error: Error; reset: () => void }) {
+  const router = useRouter()
+  return (
+    <button
+      onClick={() => {
+        router.invalidate()
+      }}
+    >
+      Retry
+    </button>
+  )
+}
+```
+
+## Cross-References
+
+- **router-core/data-loading** — `notFound()` thrown in loaders interacts with error boundaries and loader data availability. `errorComponent` retry requires `router.invalidate()`.
+- **router-core/type-safety** — `notFoundComponent` data is typed as `unknown`; validate before use.

--- a/.agents/skills/tanstack-router-core-not-found-and-errors/SKILL.md
+++ b/.agents/skills/tanstack-router-core-not-found-and-errors/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   masking (mask option, createRouteMask, unmaskOnReload).
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:
@@ -431,5 +431,5 @@ function ErrorFallback({ error }: { error: Error; reset: () => void }) {
 
 ## Cross-References
 
-- **router-core/data-loading** — `notFound()` thrown in loaders interacts with error boundaries and loader data availability. `errorComponent` retry requires `router.invalidate()`.
-- **router-core/type-safety** — `notFoundComponent` data is typed as `unknown`; validate before use.
+- **tanstack-router-core-data-loading** — `notFound()` thrown in loaders interacts with error boundaries and loader data availability. `errorComponent` retry requires `router.invalidate()`.
+- **tanstack-router-core-type-safety** — `notFoundComponent` data is typed as `unknown`; validate before use.

--- a/.agents/skills/tanstack-router-core-not-found-and-errors/SKILL.md
+++ b/.agents/skills/tanstack-router-core-not-found-and-errors/SKILL.md
@@ -9,7 +9,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/not-found-errors.md
   - TanStack/router:docs/router/guide/route-masking.md

--- a/.agents/skills/tanstack-router-core-path-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-path-params/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: tanstack-router-core-path-params
+description: >-
+  Dynamic path segments ($paramName), splat routes ($ / _splat),
+  optional params ({-$paramName}), prefix/suffix patterns ({$param}.ext),
+  useParams, params.parse/stringify, pathParamsAllowedCharacters,
+  i18n locale patterns.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/path-params.md
+  - TanStack/router:docs/router/routing/routing-concepts.md
+  - TanStack/router:docs/router/guide/internationalization-i18n.md
+---
+
+# Path Params
+
+Path params capture dynamic URL segments into named variables. They are defined with a `$` prefix in the route path.
+
+> **CRITICAL**: Never interpolate params into the `to` string. Always use the `params` prop. This is the most common agent mistake for path params.
+
+> **CRITICAL**: Types are fully inferred. Never annotate the return of `useParams()`.
+
+## Dynamic Segments
+
+A segment prefixed with `$` captures text until the next `/`.
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    // params.postId is string — fully inferred, do not annotate
+    return fetchPost(params.postId)
+  },
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { postId } = Route.useParams()
+  const data = Route.useLoaderData()
+  return (
+    <h1>
+      Post {postId}: {data.title}
+    </h1>
+  )
+}
+```
+
+Multiple dynamic segments work across path levels:
+
+```tsx
+// src/routes/teams.$teamId.members.$memberId.tsx
+export const Route = createFileRoute('/teams/$teamId/members/$memberId')({
+  component: MemberComponent,
+})
+
+function MemberComponent() {
+  const { teamId, memberId } = Route.useParams()
+  return (
+    <div>
+      Team {teamId}, Member {memberId}
+    </div>
+  )
+}
+```
+
+## Splat / Catch-All Routes
+
+A route with a path ending in `$` (bare dollar sign) captures everything after it. The value is available under the `_splat` key.
+
+```tsx
+// src/routes/files.$.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/files/$')({
+  component: FileViewer,
+})
+
+function FileViewer() {
+  const { _splat } = Route.useParams()
+  // URL: /files/documents/report.pdf → _splat = "documents/report.pdf"
+  return <div>File path: {_splat}</div>
+}
+```
+
+## Optional Params
+
+Optional params use `{-$paramName}` syntax. The segment may or may not be present. When absent, the value is `undefined`.
+
+```tsx
+// src/routes/posts.{-$category}.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/{-$category}')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const { category } = Route.useParams()
+  // URL: /posts → category is undefined
+  // URL: /posts/tech → category is "tech"
+  return <div>{category ? `Posts in ${category}` : 'All Posts'}</div>
+}
+```
+
+Multiple optional params:
+
+```tsx
+// Matches: /posts, /posts/tech, /posts/tech/hello-world
+export const Route = createFileRoute('/posts/{-$category}/{-$slug}')({
+  component: PostComponent,
+})
+```
+
+### i18n with Optional Locale
+
+```tsx
+// src/routes/{-$locale}/about.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/{-$locale}/about')({
+  component: AboutComponent,
+})
+
+function AboutComponent() {
+  const { locale } = Route.useParams()
+  const currentLocale = locale || 'en'
+  return <h1>{currentLocale === 'fr' ? 'À Propos' : 'About Us'}</h1>
+}
+// Matches: /about, /en/about, /fr/about
+```
+
+## Prefix and Suffix Patterns
+
+Curly braces `{}` around `$paramName` allow text before or after the dynamic part within a single segment.
+
+### Prefix
+
+```tsx
+// src/routes/posts/post-{$postId}.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/post-{$postId}')({
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { postId } = Route.useParams()
+  // URL: /posts/post-123 → postId = "123"
+  return <div>Post ID: {postId}</div>
+}
+```
+
+### Suffix
+
+```tsx
+// src/routes/files/{$fileName}[.]txt.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/files/{$fileName}.txt')({
+  component: FileComponent,
+})
+
+function FileComponent() {
+  const { fileName } = Route.useParams()
+  // URL: /files/readme.txt → fileName = "readme"
+  return <div>File: {fileName}.txt</div>
+}
+```
+
+### Combined Prefix + Suffix
+
+```tsx
+// URL: /users/user-456.json → userId = "456"
+export const Route = createFileRoute('/users/user-{$userId}.json')({
+  component: UserComponent,
+})
+
+function UserComponent() {
+  const { userId } = Route.useParams()
+  return <div>User: {userId}</div>
+}
+```
+
+## Navigating with Path Params
+
+### Object Form
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function PostLink({ postId }: { postId: string }) {
+  return (
+    <Link to="/posts/$postId" params={{ postId }}>
+      View Post
+    </Link>
+  )
+}
+```
+
+### Function Form (Preserves Other Params)
+
+```tsx
+function PostLink({ postId }: { postId: string }) {
+  return (
+    <Link to="/posts/$postId" params={(prev) => ({ ...prev, postId })}>
+      View Post
+    </Link>
+  )
+}
+```
+
+### Programmatic Navigation
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function GoToPost({ postId }: { postId: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <button
+      onClick={() => {
+        navigate({ to: '/posts/$postId', params: { postId } })
+      }}
+    >
+      Go to Post
+    </button>
+  )
+}
+```
+
+### Navigating with Optional Params
+
+```tsx
+// Include the optional param
+<Link to="/posts/{-$category}" params={{ category: 'tech' }}>
+  Tech Posts
+</Link>
+
+// Omit the optional param (renders /posts)
+<Link to="/posts/{-$category}" params={{ category: undefined }}>
+  All Posts
+</Link>
+```
+
+## Reading Params Outside Route Components
+
+### `useParams` with `from`
+
+```tsx
+import { useParams } from '@tanstack/react-router'
+
+function PostHeader() {
+  const { postId } = useParams({ from: '/posts/$postId' })
+  return <h2>Post {postId}</h2>
+}
+```
+
+### `useParams` with `strict: false`
+
+```tsx
+function GenericBreadcrumb() {
+  const params = useParams({ strict: false })
+  // params is a union of all possible route params
+  return <span>{params.postId ?? 'Home'}</span>
+}
+```
+
+## Params in Loaders and `beforeLoad`
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  beforeLoad: async ({ params }) => {
+    // params.postId available here
+    const canView = await checkPermission(params.postId)
+    if (!canView) throw redirect({ to: '/unauthorized' })
+  },
+  loader: async ({ params }) => {
+    return fetchPost(params.postId)
+  },
+})
+```
+
+## Allowed Characters
+
+By default, params are encoded with `encodeURIComponent`. Allow extra characters via router config:
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  pathParamsAllowedCharacters: ['@', '+'],
+})
+```
+
+Allowed characters: `;`, `:`, `@`, `&`, `=`, `+`, `$`, `,`.
+
+## Common Mistakes
+
+### 1. CRITICAL (cross-skill): Interpolating path params into `to` string
+
+```tsx
+// WRONG — breaks type safety and param encoding
+<Link to={`/posts/${postId}`}>Post</Link>
+
+// CORRECT — use params prop
+<Link to="/posts/$postId" params={{ postId }}>Post</Link>
+```
+
+### 2. MEDIUM: Using `*` for splat routes instead of `$`
+
+TanStack Router uses `$` for splat routes. The captured value is under `_splat`, not `*`.
+
+```tsx
+// WRONG (React Router / other frameworks)
+// <Route path="/files/*" />
+
+// CORRECT (TanStack Router)
+// File: src/routes/files.$.tsx
+export const Route = createFileRoute('/files/$')({
+  component: () => {
+    const { _splat } = Route.useParams()
+    return <div>{_splat}</div>
+  },
+})
+```
+
+> Note: `*` works in v1 for backwards compatibility but will be removed in v2. Always use `_splat`.
+
+### 3. MEDIUM: Using curly braces for basic dynamic segments
+
+Curly braces are ONLY for prefix/suffix patterns and optional params. Basic dynamic segments use bare `$`.
+
+```tsx
+// WRONG — braces not needed for basic params
+createFileRoute('/posts/{$postId}')
+
+// CORRECT — bare $ for basic dynamic segments
+createFileRoute('/posts/$postId')
+
+// CORRECT — braces for prefix pattern
+createFileRoute('/posts/post-{$postId}')
+
+// CORRECT — braces for optional param
+createFileRoute('/posts/{-$category}')
+```
+
+### 4. Params are always strings
+
+Path params are always parsed as strings. If you need a number, parse in the loader or component:
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    const id = parseInt(params.postId, 10)
+    if (isNaN(id)) throw notFound()
+    return fetchPost(id)
+  },
+})
+```
+
+You can also use `params.parse` and `params.stringify` on the route for bidirectional transformation:
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  params: {
+    parse: (raw) => ({ postId: parseInt(raw.postId, 10) }),
+    stringify: (parsed) => ({ postId: String(parsed.postId) }),
+  },
+  loader: async ({ params }) => {
+    // params.postId is now number
+    return fetchPost(params.postId)
+  },
+})
+```

--- a/.agents/skills/tanstack-router-core-path-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-path-params/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   i18n locale patterns.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:

--- a/.agents/skills/tanstack-router-core-path-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-path-params/SKILL.md
@@ -9,7 +9,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/path-params.md
   - TanStack/router:docs/router/routing/routing-concepts.md

--- a/.agents/skills/tanstack-router-core-search-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-search-params/SKILL.md
@@ -9,7 +9,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/search-params.md
   - TanStack/router:docs/router/how-to/setup-basic-search-params.md

--- a/.agents/skills/tanstack-router-core-search-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-search-params/SKILL.md
@@ -35,16 +35,20 @@ npm install zod @tanstack/zod-adapter
 ```tsx
 // src/routes/products.tsx
 import { createFileRoute } from '@tanstack/react-router'
+import { fallback, zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 
 const productSearchSchema = z.object({
-  page: z.number().default(1).catch(1),
+  page: fallback(z.number().default(1), 1),
   filter: z.string().default(''),
-  sort: z.enum(['newest', 'oldest', 'price']).default('newest').catch('newest'),
+  sort: fallback(
+    z.enum(['newest', 'oldest', 'price']).default('newest'),
+    'newest',
+  ),
 })
 
 export const Route = createFileRoute('/products')({
-  validateSearch: productSearchSchema,
+  validateSearch: zodValidator(productSearchSchema),
   component: ProductsPage,
 })
 
@@ -165,14 +169,15 @@ Parent route search params are automatically merged into child routes:
 ```tsx
 // src/routes/shop.tsx — parent defines shared params
 import { createFileRoute } from '@tanstack/react-router'
+import { fallback, zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 
 const shopSearchSchema = z.object({
-  currency: z.enum(['USD', 'EUR']).default('USD').catch('USD'),
+  currency: fallback(z.enum(['USD', 'EUR']).default('USD'), 'USD'),
 })
 
 export const Route = createFileRoute('/shop')({
-  validateSearch: shopSearchSchema,
+  validateSearch: zodValidator(shopSearchSchema),
 })
 ```
 

--- a/.agents/skills/tanstack-router-core-search-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-search-params/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inheritance, loaderDeps for cache keys, reading and writing search params.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:
@@ -29,7 +29,7 @@ TanStack Router treats search params as JSON-first application state. They are a
 ## Setup: Zod Adapter (Recommended)
 
 ```bash
-npm install zod @tanstack/zod-adapter
+pnpm add zod @tanstack/zod-adapter
 ```
 
 ```tsx
@@ -278,7 +278,7 @@ const router = createRouter({
 
 ```tsx
 export const Route = createFileRoute('/products')({
-  validateSearch: productSearchSchema,
+  validateSearch: zodValidator(productSearchSchema),
   // Pick ONLY the params the loader needs — not the entire search object
   loaderDeps: ({ search }) => ({ page: search.page }),
   loader: async ({ deps }) => {

--- a/.agents/skills/tanstack-router-core-search-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-search-params/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: tanstack-router-core-search-params
+description: >-
+  validateSearch, search param validation with Zod/Valibot/ArkType adapters,
+  fallback(), search middlewares (retainSearchParams, stripSearchParams),
+  custom serialization (parseSearch, stringifySearch), search param
+  inheritance, loaderDeps for cache keys, reading and writing search params.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/search-params.md
+  - TanStack/router:docs/router/how-to/setup-basic-search-params.md
+  - TanStack/router:docs/router/how-to/validate-search-params.md
+  - TanStack/router:docs/router/how-to/navigate-with-search-params.md
+  - TanStack/router:docs/router/how-to/share-search-params-across-routes.md
+  - TanStack/router:docs/router/guide/custom-search-param-serialization.md
+---
+
+# Search Params
+
+TanStack Router treats search params as JSON-first application state. They are automatically parsed from the URL into structured objects (numbers, booleans, arrays, nested objects) and validated via `validateSearch` on each route.
+
+> **CRITICAL**: When using `zodValidator()` and Zod v3, use `fallback()` from `@tanstack/zod-adapter`, NOT zod's `.catch()`. Using `.catch()` with the zod adapter makes the output type `unknown`, destroying type safety. This does not apply to Valibot or ArkType (which use their own fallback mechanisms). It also does not apply to Zod v4, which should use `.catch()` and not use the `zodValidator()`.
+> **CRITICAL**: Types are fully inferred. Never annotate the return of `useSearch()`.
+
+## Setup: Zod Adapter (Recommended)
+
+```bash
+npm install zod @tanstack/zod-adapter
+```
+
+```tsx
+// src/routes/products.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const productSearchSchema = z.object({
+  page: z.number().default(1).catch(1),
+  filter: z.string().default(''),
+  sort: z.enum(['newest', 'oldest', 'price']).default('newest').catch('newest'),
+})
+
+export const Route = createFileRoute('/products')({
+  validateSearch: productSearchSchema,
+  component: ProductsPage,
+})
+
+function ProductsPage() {
+  // page: number, filter: string, sort: 'newest' | 'oldest' | 'price'
+  // ALL INFERRED — do not annotate
+  const { page, filter, sort } = Route.useSearch()
+
+  return (
+    <div>
+      <p>
+        Page {page}, filter: {filter}, sort: {sort}
+      </p>
+    </div>
+  )
+}
+```
+
+## Reading Search Params
+
+### In Route Components: `Route.useSearch()`
+
+```tsx
+function ProductsPage() {
+  const { page, sort } = Route.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+### In Code-Split Components: `getRouteApi()`
+
+```tsx
+import { getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/products')
+
+function ProductFilters() {
+  const { sort } = routeApi.useSearch()
+  return <select value={sort}>{/* options */}</select>
+}
+```
+
+### From Any Component: `useSearch({ from })`
+
+```tsx
+import { useSearch } from '@tanstack/react-router'
+
+function SortIndicator() {
+  const { sort } = useSearch({ from: '/products' })
+  return <span>Sorted by: {sort}</span>
+}
+```
+
+### Loose Access: `useSearch({ strict: false })`
+
+```tsx
+function GenericPaginator() {
+  const search = useSearch({ strict: false })
+  // search.page is number | undefined (union of all routes)
+  return <span>Page: {search.page ?? 1}</span>
+}
+```
+
+## Writing Search Params
+
+### Link with Function Form (Preserves Existing Params)
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function Pagination() {
+  return (
+    <Link
+      from="/products"
+      search={(prev) => ({ ...prev, page: prev.page + 1 })}
+    >
+      Next Page
+    </Link>
+  )
+}
+```
+
+### Link with Object Form (Replaces All Params)
+
+```tsx
+<Link to="/products" search={{ page: 1, filter: '', sort: 'newest' }}>
+  Reset
+</Link>
+```
+
+### Programmatic: `useNavigate()`
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function SortDropdown() {
+  const navigate = useNavigate({ from: '/products' })
+
+  return (
+    <select
+      onChange={(e) => {
+        navigate({
+          search: (prev) => ({ ...prev, sort: e.target.value, page: 1 }),
+        })
+      }}
+    >
+      <option value="newest">Newest</option>
+      <option value="price">Price</option>
+    </select>
+  )
+}
+```
+
+## Search Param Inheritance
+
+Parent route search params are automatically merged into child routes:
+
+```tsx
+// src/routes/shop.tsx — parent defines shared params
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const shopSearchSchema = z.object({
+  currency: z.enum(['USD', 'EUR']).default('USD').catch('USD'),
+})
+
+export const Route = createFileRoute('/shop')({
+  validateSearch: shopSearchSchema,
+})
+```
+
+```tsx
+// src/routes/shop/products.tsx — child inherits currency
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/shop/products')({
+  component: ShopProducts,
+})
+
+function ShopProducts() {
+  // currency is available here from parent — fully typed
+  const { currency } = Route.useSearch()
+  return <div>Currency: {currency}</div>
+}
+```
+
+## Search Middlewares
+
+### `retainSearchParams` — Keep Params Across Navigation
+
+```tsx
+import { createRootRoute, retainSearchParams } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const rootSearchSchema = z.object({
+  debug: z.boolean().optional(),
+})
+
+export const Route = createRootRoute({
+  validateSearch: rootSearchSchema,
+  search: {
+    middlewares: [retainSearchParams(['debug'])],
+  },
+})
+```
+
+### `stripSearchParams` — Remove Default Values from URL
+
+```tsx
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const defaults = { sort: 'newest', page: 1 }
+
+const searchSchema = z.object({
+  sort: z.string().default(defaults.sort),
+  page: z.number().default(defaults.page),
+})
+
+export const Route = createFileRoute('/items')({
+  validateSearch: searchSchema,
+  search: {
+    middlewares: [stripSearchParams(defaults)],
+  },
+})
+```
+
+### Chaining Middlewares
+
+```tsx
+export const Route = createFileRoute('/search')({
+  validateSearch: z.object({
+    retainMe: z.string().optional(),
+    arrayWithDefaults: z.string().array().default(['foo', 'bar']),
+    required: z.string(),
+  }),
+  search: {
+    middlewares: [
+      retainSearchParams(['retainMe']),
+      stripSearchParams({ arrayWithDefaults: ['foo', 'bar'] }),
+    ],
+  },
+})
+```
+
+## Custom Serialization
+
+Override the default JSON serialization at the router level:
+
+```tsx
+import {
+  createRouter,
+  parseSearchWith,
+  stringifySearchWith,
+} from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  // Example: use JSURL2 for compact, human-readable URLs
+  parseSearch: parseSearchWith(parse),
+  stringifySearch: stringifySearchWith(stringify),
+})
+```
+
+## Using Search Params in Loaders via `loaderDeps`
+
+```tsx
+export const Route = createFileRoute('/products')({
+  validateSearch: productSearchSchema,
+  // Pick ONLY the params the loader needs — not the entire search object
+  loaderDeps: ({ search }) => ({ page: search.page }),
+  loader: async ({ deps }) => {
+    return fetchProducts({ page: deps.page })
+  },
+})
+```
+
+## Common Mistakes
+
+### 1. HIGH: Using zod v3's `.catch()` with `zodValidator()` instead of adapter `fallback()`
+
+```tsx
+// WRONG — .catch() with zodValidator makes the type unknown
+const schema = z.object({ page: z.number().catch(1) })
+validateSearch: zodValidator(schema) // page is typed as unknown!
+
+// CORRECT — fallback() preserves the inferred type
+import { fallback } from '@tanstack/zod-adapter'
+const schema = z.object({ page: fallback(z.number(), 1) })
+```
+
+**Important:** This only applies when using Zod v3, not when using Zod v4. For v4, using `.catch()` is correct.
+
+### 2. HIGH: Returning entire search object from `loaderDeps`
+
+```tsx
+// WRONG — loader re-runs on ANY search param change
+loaderDeps: ({ search }) => search
+
+// CORRECT — loader only re-runs when page changes
+loaderDeps: ({ search }) => ({ page: search.page })
+```
+
+### 3. HIGH: Passing Date objects in search params
+
+```tsx
+// WRONG — Date does not serialize correctly to JSON in URLs
+<Link search={{ startDate: new Date() }}>
+
+// CORRECT — convert to ISO string
+<Link search={{ startDate: new Date().toISOString() }}>
+```
+
+### 4. MEDIUM: Parent route missing `validateSearch` blocks inheritance
+
+```tsx
+// WRONG — child cannot access shared params
+export const Route = createRootRoute({
+  component: RootComponent,
+  // no validateSearch!
+})
+
+// CORRECT — parent must define validateSearch for children to inherit
+export const Route = createRootRoute({
+  validateSearch: globalSearchSchema,
+  component: RootComponent,
+})
+```
+
+### 5. HIGH (cross-skill): Using search as object instead of function loses params
+
+```tsx
+// WRONG — replaces ALL search params, losing any existing ones
+<Link to="." search={{ page: 2 }}>Page 2</Link>
+
+// CORRECT — preserves existing params, updates only page
+<Link to="." search={(prev) => ({ ...prev, page: 2 })}>Page 2</Link>
+```
+
+## References
+
+- [Validation Patterns Reference](./references/validation-patterns.md) — comprehensive patterns for all validation libraries

--- a/.agents/skills/tanstack-router-core-search-params/SKILL.md
+++ b/.agents/skills/tanstack-router-core-search-params/SKILL.md
@@ -26,14 +26,58 @@ TanStack Router treats search params as JSON-first application state. They are a
 > **CRITICAL**: When using `zodValidator()` and Zod v3, use `fallback()` from `@tanstack/zod-adapter`, NOT zod's `.catch()`. Using `.catch()` with the zod adapter makes the output type `unknown`, destroying type safety. This does not apply to Valibot or ArkType (which use their own fallback mechanisms). It also does not apply to Zod v4, which should use `.catch()` and not use the `zodValidator()`.
 > **CRITICAL**: Types are fully inferred. Never annotate the return of `useSearch()`.
 
-## Setup: Zod Adapter (Recommended)
+## Setup: Zod (Recommended)
+
+> **This repo uses Zod v4** (`apps/web/package.json`: `zod: ^4.3.6`). With Zod v4, schemas satisfy StandardSchema, so pass the schema **directly** to `validateSearch` — no `zodValidator()` adapter required. Use `.catch()` for fallback defaults on invalid values.
+
+```bash
+pnpm add zod
+```
+
+```tsx
+// src/routes/products.tsx — Zod v4 (this repo)
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const productSearchSchema = z.object({
+  page: z.number().default(1).catch(1),
+  filter: z.string().default('').catch(''),
+  sort: z
+    .enum(['newest', 'oldest', 'price'])
+    .default('newest')
+    .catch('newest'),
+})
+
+export const Route = createFileRoute('/products')({
+  validateSearch: productSearchSchema,
+  component: ProductsPage,
+})
+
+function ProductsPage() {
+  // page: number, filter: string, sort: 'newest' | 'oldest' | 'price'
+  // ALL INFERRED — do not annotate
+  const { page, filter, sort } = Route.useSearch()
+
+  return (
+    <div>
+      <p>
+        Page {page}, filter: {filter}, sort: {sort}
+      </p>
+    </div>
+  )
+}
+```
+
+## Setup: Zod v3 (legacy) — `zodValidator` adapter
+
+For Zod **v3 only**, wrap the schema with `zodValidator()` from `@tanstack/zod-adapter` and use `fallback()` (NOT zod's `.catch()`, which makes the output type `unknown` when used with the adapter). This repo uses Zod v4, so prefer the section above.
 
 ```bash
 pnpm add zod @tanstack/zod-adapter
 ```
 
 ```tsx
-// src/routes/products.tsx
+// src/routes/products.tsx — Zod v3 (legacy)
 import { createFileRoute } from '@tanstack/react-router'
 import { fallback, zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
@@ -51,20 +95,6 @@ export const Route = createFileRoute('/products')({
   validateSearch: zodValidator(productSearchSchema),
   component: ProductsPage,
 })
-
-function ProductsPage() {
-  // page: number, filter: string, sort: 'newest' | 'oldest' | 'price'
-  // ALL INFERRED — do not annotate
-  const { page, filter, sort } = Route.useSearch()
-
-  return (
-    <div>
-      <p>
-        Page {page}, filter: {filter}, sort: {sort}
-      </p>
-    </div>
-  )
-}
 ```
 
 ## Reading Search Params
@@ -167,17 +197,16 @@ function SortDropdown() {
 Parent route search params are automatically merged into child routes:
 
 ```tsx
-// src/routes/shop.tsx — parent defines shared params
+// src/routes/shop.tsx — parent defines shared params (Zod v4)
 import { createFileRoute } from '@tanstack/react-router'
-import { fallback, zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 
 const shopSearchSchema = z.object({
-  currency: fallback(z.enum(['USD', 'EUR']).default('USD'), 'USD'),
+  currency: z.enum(['USD', 'EUR']).default('USD').catch('USD'),
 })
 
 export const Route = createFileRoute('/shop')({
-  validateSearch: zodValidator(shopSearchSchema),
+  validateSearch: shopSearchSchema,
 })
 ```
 
@@ -278,7 +307,7 @@ const router = createRouter({
 
 ```tsx
 export const Route = createFileRoute('/products')({
-  validateSearch: zodValidator(productSearchSchema),
+  validateSearch: productSearchSchema, // Zod v4: pass schema directly
   // Pick ONLY the params the loader needs — not the entire search object
   loaderDeps: ({ search }) => ({ page: search.page }),
   loader: async ({ deps }) => {

--- a/.agents/skills/tanstack-router-core-search-params/references/validation-patterns.md
+++ b/.agents/skills/tanstack-router-core-search-params/references/validation-patterns.md
@@ -1,0 +1,379 @@
+# Search Param Validation Patterns Reference
+
+Comprehensive validation patterns for TanStack Router search params across all supported validation approaches.
+
+## Zod with `@tanstack/zod-adapter`
+
+Zod v3 does not implement Standard Schema, so the `@tanstack/zod-adapter` wrapper is required. Always use `fallback()` from the adapter instead of zod's `.catch()`. Always wrap with `zodValidator()`.
+
+### Basic Types
+
+```tsx
+import { zodValidator, fallback } from '@tanstack/zod-adapter'
+import { z } from 'zod'
+
+const schema = z.object({
+  count: fallback(z.number(), 0),
+  name: fallback(z.string(), ''),
+  active: fallback(z.boolean(), true),
+})
+
+export const Route = createFileRoute('/example')({
+  validateSearch: zodValidator(schema),
+})
+```
+
+### Optional Params
+
+```tsx
+const schema = z.object({
+  // Truly optional — can be undefined in component
+  searchTerm: z.string().optional(),
+  // Optional in URL but always has a value in component
+  page: fallback(z.number(), 1).default(1),
+})
+```
+
+### Default Values
+
+```tsx
+const schema = z.object({
+  // .default() means the param is optional during navigation
+  // but always present (with default) when reading
+  page: fallback(z.number(), 1).default(1),
+  sort: fallback(z.enum(['name', 'date', 'price']), 'name').default('name'),
+  ascending: fallback(z.boolean(), true).default(true),
+})
+```
+
+### Array Params
+
+```tsx
+const schema = z.object({
+  tags: fallback(z.string().array(), []).default([]),
+  selectedIds: fallback(z.number().array(), []).default([]),
+})
+
+// URL: /items?tags=%5B%22react%22%2C%22typescript%22%5D&selectedIds=%5B1%2C2%2C3%5D
+// Parsed: { tags: ['react', 'typescript'], selectedIds: [1, 2, 3] }
+```
+
+### Nested Object Params
+
+```tsx
+const schema = z.object({
+  filters: fallback(
+    z.object({
+      status: z.enum(['active', 'inactive']).optional(),
+      tags: z.string().array().optional(),
+      priceRange: z
+        .object({
+          min: z.number().min(0),
+          max: z.number().min(0),
+        })
+        .optional(),
+    }),
+    {},
+  ).default({}),
+})
+```
+
+### Enum with Constraints
+
+```tsx
+const schema = z.object({
+  sort: fallback(z.enum(['newest', 'oldest', 'price']), 'newest').default(
+    'newest',
+  ),
+  page: fallback(z.number().int().min(1).max(1000), 1).default(1),
+  limit: fallback(z.number().int().min(10).max(100), 20).default(20),
+})
+```
+
+### Discriminated Union
+
+```tsx
+const schema = z.object({
+  searchType: fallback(z.enum(['basic', 'advanced']), 'basic').default('basic'),
+  query: fallback(z.string(), '').default(''),
+  // Advanced-only fields are optional
+  category: z.string().optional(),
+  minPrice: z.number().optional(),
+  maxPrice: z.number().optional(),
+})
+```
+
+For true discriminated union validation:
+
+```tsx
+const basicSearch = z.object({
+  searchType: z.literal('basic'),
+  query: z.string(),
+})
+
+const advancedSearch = z.object({
+  searchType: z.literal('advanced'),
+  query: z.string(),
+  category: z.string(),
+  minPrice: z.number(),
+  maxPrice: z.number(),
+})
+
+const schema = z.discriminatedUnion('searchType', [basicSearch, advancedSearch])
+
+export const Route = createFileRoute('/search')({
+  validateSearch: zodValidator(schema),
+})
+```
+
+### Input Transforms (String to Number)
+
+When using the zod adapter with transforms, configure `input` and `output` types:
+
+```tsx
+const schema = z.object({
+  page: fallback(z.number(), 1).default(1),
+  filter: fallback(z.string(), '').default(''),
+})
+
+export const Route = createFileRoute('/items')({
+  // Default: input type used for navigation, output type used for reading
+  validateSearch: zodValidator(schema),
+
+  // Advanced: swap input/output inference
+  // validateSearch: zodValidator({ schema, input: 'output', output: 'input' }),
+})
+```
+
+### Schema Composition
+
+```tsx
+const paginationSchema = z.object({
+  page: fallback(z.number().int().positive(), 1).default(1),
+  limit: fallback(z.number().int().min(1).max(100), 20).default(20),
+})
+
+const sortSchema = z.object({
+  sortBy: z.enum(['name', 'date', 'relevance']).optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+})
+
+// Compose for specific routes
+const productSearchSchema = paginationSchema.extend({
+  category: z.string().optional(),
+  inStock: fallback(z.boolean(), true).default(true),
+})
+
+const userSearchSchema = paginationSchema.merge(sortSchema).extend({
+  role: z.enum(['admin', 'user']).optional(),
+})
+```
+
+---
+
+## Valibot (Standard Schema)
+
+Valibot 1.0+ implements Standard Schema. No adapter wrapper needed — pass the schema directly to `validateSearch`. The `@tanstack/valibot-adapter` is optional and only needed for explicit input/output type control.
+
+```bash
+npm install valibot
+```
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import * as v from 'valibot'
+
+const productSearchSchema = v.object({
+  page: v.optional(v.fallback(v.number(), 1), 1),
+  filter: v.optional(v.fallback(v.string(), ''), ''),
+  sort: v.optional(
+    v.fallback(v.picklist(['newest', 'oldest', 'price']), 'newest'),
+    'newest',
+  ),
+})
+
+export const Route = createFileRoute('/products')({
+  // Pass schema directly — Standard Schema compliant
+  validateSearch: productSearchSchema,
+  component: ProductsPage,
+})
+
+function ProductsPage() {
+  const { page, filter, sort } = Route.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+### Valibot with Constraints
+
+```tsx
+import * as v from 'valibot'
+
+const schema = v.object({
+  page: v.optional(
+    v.fallback(v.pipe(v.number(), v.integer(), v.minValue(1)), 1),
+    1,
+  ),
+  query: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(100))),
+  tags: v.optional(v.fallback(v.array(v.string()), []), []),
+})
+```
+
+### Valibot with Adapter (Alternative)
+
+If you need explicit input/output type control:
+
+```tsx
+import { valibotValidator } from '@tanstack/valibot-adapter'
+import * as v from 'valibot'
+
+const schema = v.object({
+  page: v.optional(v.fallback(v.number(), 1), 1),
+})
+
+export const Route = createFileRoute('/items')({
+  validateSearch: valibotValidator(schema),
+})
+```
+
+---
+
+## ArkType (Standard Schema)
+
+ArkType 2.0-rc+ implements Standard Schema. No adapter needed — pass the type directly to `validateSearch`. The `@tanstack/arktype-adapter` is optional and only needed for explicit input/output type control.
+
+```bash
+npm install arktype
+```
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { type } from 'arktype'
+
+const productSearchSchema = type({
+  page: 'number = 1',
+  filter: 'string = ""',
+  sort: '"newest" | "oldest" | "price" = "newest"',
+})
+
+export const Route = createFileRoute('/products')({
+  // Pass directly — Standard Schema compliant
+  validateSearch: productSearchSchema,
+  component: ProductsPage,
+})
+
+function ProductsPage() {
+  const { page, filter, sort } = Route.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+### ArkType with Constraints
+
+```tsx
+import { type } from 'arktype'
+
+const searchSchema = type({
+  'query?': 'string>0&<=100',
+  page: 'number>0 = 1',
+  'sortBy?': "'name'|'date'|'relevance'",
+  'filters?': 'string[]',
+})
+```
+
+---
+
+## Manual Validation Function
+
+For full control without any library. The function receives raw JSON-parsed (but unvalidated) search params.
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+type ProductSearch = {
+  page: number
+  filter: string
+  sort: 'newest' | 'oldest' | 'price'
+}
+
+export const Route = createFileRoute('/products')({
+  validateSearch: (search: Record<string, unknown>): ProductSearch => ({
+    page: Number(search?.page ?? 1),
+    filter: (search.filter as string) || '',
+    sort:
+      search.sort === 'newest' ||
+      search.sort === 'oldest' ||
+      search.sort === 'price'
+        ? search.sort
+        : 'newest',
+  }),
+  component: ProductsPage,
+})
+
+function ProductsPage() {
+  const { page, filter, sort } = Route.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+### Manual Validation with Error Throwing
+
+If `validateSearch` throws, the route's `errorComponent` renders instead:
+
+```tsx
+export const Route = createFileRoute('/products')({
+  validateSearch: (search: Record<string, unknown>) => {
+    const page = Number(search.page)
+    if (isNaN(page) || page < 1) {
+      throw new Error('Invalid page number')
+    }
+    return { page }
+  },
+  errorComponent: ({ error }) => <div>Bad search params: {error.message}</div>,
+})
+```
+
+---
+
+## Pattern: Object with `parse` Method
+
+Any object with a `.parse()` method works as `validateSearch`:
+
+```tsx
+const mySchema = {
+  parse: (input: Record<string, unknown>) => ({
+    page: Number(input.page ?? 1),
+    query: String(input.query ?? ''),
+  }),
+}
+
+export const Route = createFileRoute('/search')({
+  validateSearch: mySchema,
+})
+```
+
+---
+
+## Dates in Search Params
+
+Never put `Date` objects in search params. Always use ISO strings:
+
+```tsx
+const schema = z.object({
+  // Store as string, parse in component if needed
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+})
+
+// In component:
+function DateFilter() {
+  const { startDate } = Route.useSearch()
+  const date = startDate ? new Date(startDate) : null
+  return <div>{date?.toLocaleDateString()}</div>
+}
+
+// When navigating:
+;<Link search={(prev) => ({ ...prev, startDate: new Date().toISOString() })}>
+  Set Start Date
+</Link>
+```

--- a/.agents/skills/tanstack-router-core-search-params/references/validation-patterns.md
+++ b/.agents/skills/tanstack-router-core-search-params/references/validation-patterns.md
@@ -176,7 +176,7 @@ const userSearchSchema = paginationSchema.merge(sortSchema).extend({
 Valibot 1.0+ implements Standard Schema. No adapter wrapper needed — pass the schema directly to `validateSearch`. The `@tanstack/valibot-adapter` is optional and only needed for explicit input/output type control.
 
 ```bash
-npm install valibot
+pnpm add valibot
 ```
 
 ```tsx
@@ -243,7 +243,7 @@ export const Route = createFileRoute('/items')({
 ArkType 2.0-rc+ implements Standard Schema. No adapter needed — pass the type directly to `validateSearch`. The `@tanstack/arktype-adapter` is optional and only needed for explicit input/output type control.
 
 ```bash
-npm install arktype
+pnpm add arktype
 ```
 
 ```tsx

--- a/.agents/skills/tanstack-router-core-ssr/SKILL.md
+++ b/.agents/skills/tanstack-router-core-ssr/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: tanstack-router-core-ssr
+description: >-
+  Non-streaming and streaming SSR, RouterClient/RouterServer,
+  renderRouterToString/renderRouterToStream, createRequestHandler,
+  defaultRenderHandler/defaultStreamHandler, HeadContent/Scripts
+  components, head route option (meta/links/styles/scripts),
+  ScriptOnce, automatic loader dehydration/hydration, memory
+  history on server, data serialization, document head management.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+  - router-core/data-loading
+sources:
+  - TanStack/router:docs/router/guide/ssr.md
+  - TanStack/router:docs/router/guide/document-head-management.md
+  - TanStack/router:docs/router/how-to/setup-ssr.md
+---
+
+# SSR (Server-Side Rendering)
+
+> **WARNING**: SSR APIs are experimental. They share internal implementations with TanStack Start and may change. **TanStack Start is the recommended way to do SSR in production** — use manual SSR setup only when integrating with an existing server.
+
+> **CRITICAL**: TanStack Router is CLIENT-FIRST. Loaders run on the client by default. With SSR enabled, loaders run on BOTH client AND server. They are NOT server-only like Remix/Next.js loaders. See [router-core/data-loading](../tanstack-router-core-data-loading/SKILL.md).
+
+> **CRITICAL**: Do not generate Next.js patterns (`getServerSideProps`, App Router, server components) or Remix patterns (server-only loader exports). TanStack Router has its own SSR API.
+
+## Concepts
+
+There are two SSR flavors:
+
+- **Non-streaming**: Full page rendered on server, sent as one HTML response, then hydrated on client.
+- **Streaming**: Critical first paint sent immediately; remaining content streamed incrementally as it resolves.
+
+Key behaviors:
+
+- Memory history is used automatically on the server (no `window`).
+- Loader data is automatically dehydrated on the server and hydrated on the client.
+- Data serialization supports `Date`, `Error`, `FormData`, and `undefined` out of the box.
+
+## Setup: Shared Router Factory
+
+The router must be created identically on server and client. Export a factory function from a shared file:
+
+```tsx
+// src/router.tsx
+import { createRouter as createTanstackRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export function createRouter() {
+  return createTanstackRouter({ routeTree })
+}
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: ReturnType<typeof createRouter>
+  }
+}
+```
+
+## Non-Streaming SSR
+
+### Server Entry (using `defaultRenderHandler`)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  defaultRenderHandler,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export async function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+  return await handler(defaultRenderHandler)
+}
+```
+
+### Server Entry (using `renderRouterToString` for custom wrappers)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  renderRouterToString,
+  RouterServer,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+
+  return handler(({ responseHeaders, router }) =>
+    renderRouterToString({
+      responseHeaders,
+      router,
+      children: <RouterServer router={router} />,
+    }),
+  )
+}
+```
+
+### Client Entry
+
+```tsx
+// src/entry-client.tsx
+import { hydrateRoot } from 'react-dom/client'
+import { RouterClient } from '@tanstack/react-router/ssr/client'
+import { createRouter } from './router'
+
+const router = createRouter()
+
+hydrateRoot(document, <RouterClient router={router} />)
+```
+
+## Streaming SSR
+
+### Server Entry (using `defaultStreamHandler`)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  defaultStreamHandler,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export async function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+  return await handler(defaultStreamHandler)
+}
+```
+
+### Server Entry (using `renderRouterToStream` for custom wrappers)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  renderRouterToStream,
+  RouterServer,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+
+  return handler(({ request, responseHeaders, router }) =>
+    renderRouterToStream({
+      request,
+      responseHeaders,
+      router,
+      children: <RouterServer router={router} />,
+    }),
+  )
+}
+```
+
+Streaming is automatic — deferred data (unawaited promises from loaders) and streamed markup just work when using `defaultStreamHandler` or `renderRouterToStream`.
+
+## Document Head Management
+
+Use the `head` route option to manage `<title>`, `<meta>`, `<link>`, and `<style>` tags. Render `<HeadContent />` in `<head>` and `<Scripts />` in `<body>`.
+
+### Root Route with Head
+
+```tsx
+// src/routes/__root.tsx
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [
+      { charSet: 'UTF-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1.0' },
+      { title: 'My App' },
+    ],
+    links: [{ rel: 'icon', href: '/favicon.ico' }],
+  }),
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### Per-Route Head (Nested Deduplication)
+
+Child route `title` and `meta` tags override parent tags with the same `name`/`property`:
+
+```tsx
+// src/routes/posts/$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    const post = await fetchPost(params.postId)
+    return { post }
+  },
+  head: ({ loaderData }) => ({
+    meta: [
+      { title: loaderData.post.title },
+      { name: 'description', content: loaderData.post.excerpt },
+    ],
+  }),
+  component: PostPage,
+})
+
+function PostPage() {
+  const { post } = Route.useLoaderData()
+  return <article>{post.content}</article>
+}
+```
+
+### SPA Head (No Full HTML Control)
+
+For SPAs without server-rendered HTML, render `<HeadContent />` at the top of the component tree:
+
+```tsx
+import { createRootRoute, HeadContent, Outlet } from '@tanstack/react-router'
+
+const rootRoute = createRootRoute({
+  head: () => ({
+    meta: [{ title: 'My SPA' }],
+  }),
+  component: () => (
+    <>
+      <HeadContent />
+      <Outlet />
+    </>
+  ),
+})
+```
+
+## Body Scripts
+
+Use `scripts` (separate from `head.scripts`) to inject scripts into `<body>` before the app entry point:
+
+```tsx
+export const Route = createRootRoute({
+  scripts: () => [{ children: 'console.log("runs before hydration")' }],
+})
+```
+
+The `<Scripts />` component renders these. Place it at the end of `<body>`.
+
+## ScriptOnce for Pre-Hydration Scripts
+
+`ScriptOnce` renders a `<script>` during SSR that executes immediately and self-removes. On client navigation, it does nothing (no duplicate execution).
+
+```tsx
+import { ScriptOnce } from '@tanstack/react-router'
+
+const themeScript = `(function() {
+  try {
+    const theme = localStorage.getItem('theme') || 'auto';
+    const resolved = theme === 'auto'
+      ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : theme;
+    document.documentElement.classList.add(resolved);
+  } catch (e) {}
+})();`
+
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <ScriptOnce children={themeScript} />
+      {children}
+    </>
+  )
+}
+```
+
+If the script modifies the DOM (e.g., adds a class to `<html>`), use `suppressHydrationWarning` on the element:
+
+```tsx
+<html lang="en" suppressHydrationWarning>
+```
+
+## Express Integration Example
+
+`createRequestHandler` expects a Web API `Request` and returns a Web API `Response`. For Express, convert between formats:
+
+```tsx
+// src/entry-server.tsx
+import { pipeline } from 'node:stream/promises'
+import {
+  RouterServer,
+  createRequestHandler,
+  renderRouterToString,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+import type express from 'express'
+
+export async function render({
+  req,
+  res,
+}: {
+  req: express.Request
+  res: express.Response
+}) {
+  const protocol = req.get('x-forwarded-proto') ?? req.protocol
+  const host = req.get('x-forwarded-host') ?? req.get('host')
+  const url = new URL(req.originalUrl || req.url, `${protocol}://${host}`).href
+
+  const request = new Request(url, {
+    method: req.method,
+    headers: (() => {
+      const headers = new Headers()
+      for (const [key, value] of Object.entries(req.headers)) {
+        headers.set(key, value as any)
+      }
+      return headers
+    })(),
+  })
+
+  const handler = createRequestHandler({ request, createRouter })
+
+  const response = await handler(({ responseHeaders, router }) =>
+    renderRouterToString({
+      responseHeaders,
+      router,
+      children: <RouterServer router={router} />,
+    }),
+  )
+
+  res.status(response.status)
+  response.headers.forEach((value, name) => {
+    res.setHeader(name, value)
+  })
+
+  return pipeline(response.body as any, res)
+}
+```
+
+## Common Mistakes
+
+### 1. HIGH: Using browser APIs in loaders without environment check
+
+Loaders run on BOTH client and server with SSR. Browser-only APIs (`window`, `document`, `localStorage`) throw on the server.
+
+```tsx
+// WRONG — crashes on server
+loader: async () => {
+  const token = localStorage.getItem('token')
+  return fetchData(token)
+}
+
+// CORRECT — guard with environment check
+loader: async () => {
+  const token =
+    typeof window !== 'undefined' ? localStorage.getItem('token') : null
+  return fetchData(token)
+}
+```
+
+### 2. MEDIUM: Using hash fragments for server-rendered content
+
+Hash fragments (`#section`) are never sent to the server. Conditional rendering based on hash causes hydration mismatches.
+
+```tsx
+// WRONG — server has no hash, client does → mismatch
+component: () => {
+  const hash = window.location.hash
+  return hash === '#admin' ? <AdminPanel /> : <UserPanel />
+}
+
+// CORRECT — use search params for server-visible state
+validateSearch: z.object({ view: fallback(z.enum(['admin', 'user']), 'user') }),
+component: () => {
+  const { view } = Route.useSearch()
+  return view === 'admin' ? <AdminPanel /> : <UserPanel />
+}
+```
+
+### 3. CRITICAL: Generating Next.js or Remix SSR patterns
+
+TanStack Router does NOT use `getServerSideProps`, `getStaticProps`, App Router `page.tsx`, or Remix-style server-only `loader` exports.
+
+```tsx
+// WRONG — Next.js patterns
+export async function getServerSideProps() {
+  return { props: { data: await fetchData() } }
+}
+
+// WRONG — Remix patterns
+export async function loader({ request }: LoaderFunctionArgs) {
+  return json({ data: await fetchData() })
+}
+
+// CORRECT — TanStack Router pattern
+export const Route = createFileRoute('/data')({
+  loader: async () => {
+    const data = await fetchData()
+    return { data }
+  },
+  component: DataPage,
+})
+
+function DataPage() {
+  const { data } = Route.useLoaderData()
+  return <div>{data}</div>
+}
+```
+
+## Tension: Client-First Loaders vs SSR
+
+TanStack Router loaders are client-first by design. When SSR is enabled, they run in both environments. This means:
+
+- Browser APIs work by default (client-only) but break under SSR
+- Database access does NOT belong in loaders (unlike Remix/Next) — use API routes
+- For server-only data logic with SSR, use TanStack Start's server functions
+
+See [router-core/data-loading](../tanstack-router-core-data-loading/SKILL.md) for loader fundamentals.
+
+## Cross-References
+
+- [router-core/data-loading](../tanstack-router-core-data-loading/SKILL.md) — SSR changes where loaders execute
+- compositions/router-query — SSR dehydration/hydration with TanStack Query, if that separate composition skill is installed

--- a/.agents/skills/tanstack-router-core-ssr/SKILL.md
+++ b/.agents/skills/tanstack-router-core-ssr/SKILL.md
@@ -11,8 +11,8 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
-  - router-core/data-loading
+  - tanstack-router-core
+  - tanstack-router-core-data-loading
 sources:
   - TanStack/router:docs/router/guide/ssr.md
   - TanStack/router:docs/router/guide/document-head-management.md

--- a/.agents/skills/tanstack-router-core-ssr/SKILL.md
+++ b/.agents/skills/tanstack-router-core-ssr/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   history on server, data serialization, document head management.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
   - tanstack-router-core-data-loading
@@ -23,7 +23,7 @@ sources:
 
 > **WARNING**: SSR APIs are experimental. They share internal implementations with TanStack Start and may change. **TanStack Start is the recommended way to do SSR in production** — use manual SSR setup only when integrating with an existing server.
 
-> **CRITICAL**: TanStack Router is CLIENT-FIRST. Loaders run on the client by default. With SSR enabled, loaders run on BOTH client AND server. They are NOT server-only like Remix/Next.js loaders. See [router-core/data-loading](../tanstack-router-core-data-loading/SKILL.md).
+> **CRITICAL**: TanStack Router is CLIENT-FIRST. Loaders run on the client by default. With SSR enabled, loaders run on BOTH client AND server. They are NOT server-only like Remix/Next.js loaders. See [tanstack-router-core-data-loading](../tanstack-router-core-data-loading/SKILL.md).
 
 > **CRITICAL**: Do not generate Next.js patterns (`getServerSideProps`, App Router, server components) or Remix patterns (server-only loader exports). TanStack Router has its own SSR API.
 
@@ -429,9 +429,9 @@ TanStack Router loaders are client-first by design. When SSR is enabled, they ru
 - Database access does NOT belong in loaders (unlike Remix/Next) — use API routes
 - For server-only data logic with SSR, use TanStack Start's server functions
 
-See [router-core/data-loading](../tanstack-router-core-data-loading/SKILL.md) for loader fundamentals.
+See [tanstack-router-core-data-loading](../tanstack-router-core-data-loading/SKILL.md) for loader fundamentals.
 
 ## Cross-References
 
-- [router-core/data-loading](../tanstack-router-core-data-loading/SKILL.md) — SSR changes where loaders execute
+- [tanstack-router-core-data-loading](../tanstack-router-core-data-loading/SKILL.md) — SSR changes where loaders execute
 - compositions/router-query — SSR dehydration/hydration with TanStack Query, if that separate composition skill is installed

--- a/.agents/skills/tanstack-router-core-type-safety/SKILL.md
+++ b/.agents/skills/tanstack-router-core-type-safety/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: tanstack-router-core-type-safety
+description: >-
+  Full type inference philosophy (never cast, never annotate inferred
+  values), Register module declaration, from narrowing on hooks and
+  Link, strict:false for shared components, getRouteApi for code-split
+  typed access, addChildren with object syntax for TS perf, LinkProps
+  and ValidateLinkOptions type utilities, as const satisfies pattern.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/type-safety.md
+  - TanStack/router:docs/router/guide/type-utilities.md
+  - TanStack/router:docs/router/guide/render-optimizations.md
+---
+
+# Type Safety
+
+TanStack Router is FULLY type-inferred. Params, search params, context, and loader data all flow through the route tree automatically. The **#1 AI agent mistake** is adding type annotations, casts, or generic parameters to values that are already inferred.
+
+> **CRITICAL**: NEVER use `as Type`, explicit generic params, `satisfies` on hook returns, or type annotations on inferred values. Every cast masks real type errors and breaks the inference chain.
+> **CRITICAL**: Do NOT confuse TanStack Router with Next.js or React Router. There is no `getServerSideProps`, no `useSearchParams()`, no `useLoaderData()` from `react-router-dom`.
+
+## The ONE Required Type Annotation: Register
+
+Without this, top-level exports like `Link`, `useNavigate`, `useSearch` have no type safety.
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({ routeTree })
+
+// THIS IS REQUIRED — the single type registration for the entire app
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+export default router
+```
+
+After registration, every `Link`, `useNavigate`, `useSearch`, `useParams` across the app is fully typed.
+
+## Types Flow Automatically
+
+### Route Hooks — No Annotation Needed
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    page: Number(search.page ?? 1),
+  }),
+  loader: async ({ params }) => {
+    // params.postId is already typed as string — do not annotate
+    const post = await fetchPost(params.postId)
+    return { post }
+  },
+  component: PostComponent,
+})
+
+function PostComponent() {
+  // ALL of these are fully inferred — do NOT add type annotations
+  const { postId } = Route.useParams()
+  //      ^? string
+
+  const { page } = Route.useSearch()
+  //      ^? number
+
+  const { post } = Route.useLoaderData()
+  //      ^? { id: string; title: string; body: string }
+
+  return (
+    <div>
+      <h1>{post.title}</h1>
+      <p>Page {page}</p>
+    </div>
+  )
+}
+```
+
+### Context Flows Through the Tree
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+
+interface RouterContext {
+  auth: { userId: string; role: 'admin' | 'user' } | null
+}
+
+// Note: createRootRouteWithContext is a FACTORY — call it TWICE: ()()
+export const Route = createRootRouteWithContext<RouterContext>()({
+  component: () => <Outlet />,
+})
+```
+
+```tsx
+// src/routes/dashboard.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/dashboard')({
+  beforeLoad: ({ context }) => {
+    // context.auth is already typed as { userId: string; role: 'admin' | 'user' } | null
+    // NO annotation needed
+    if (!context.auth) throw redirect({ to: '/login' })
+    return { user: context.auth }
+  },
+  loader: ({ context }) => {
+    // context.user is typed as { userId: string; role: 'admin' | 'user' }
+    // This was added by beforeLoad above — fully inferred
+    return fetchDashboard(context.user.userId)
+  },
+  component: DashboardComponent,
+})
+
+function DashboardComponent() {
+  const data = Route.useLoaderData()
+  const { user } = Route.useRouteContext()
+  return <h1>Welcome {user.userId}</h1>
+}
+```
+
+## Narrowing with `from`
+
+Without `from`, hooks return a union of ALL routes' types — slow for TypeScript and imprecise.
+
+### On Hooks
+
+```tsx
+import { useSearch, useParams, useNavigate } from '@tanstack/react-router'
+
+function PostSidebar() {
+  // WRONG — search is a union of ALL routes' search params
+  const search = useSearch()
+
+  // CORRECT — search is narrowed to /posts/$postId's search params
+  const search = useSearch({ from: '/posts/$postId' })
+  //    ^? { page: number }
+
+  // CORRECT — params narrowed to this route
+  const { postId } = useParams({ from: '/posts/$postId' })
+
+  // CORRECT — navigate narrowed for relative paths
+  const navigate = useNavigate({ from: '/posts/$postId' })
+}
+```
+
+### On `Link`
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+// WRONG — search resolves to union of ALL routes' search params, slow TS check
+<Link to=".." search={{ page: 0 }} />
+
+// CORRECT — narrowed, fast TS check
+<Link from="/posts/$postId" to=".." search={{ page: 0 }} />
+
+// Also correct — Route.fullPath in route components
+<Link from={Route.fullPath} to=".." search={{ page: 0 }} />
+```
+
+## Shared Components: `strict: false`
+
+When a component is used across multiple routes, use `strict: false` instead of `from`:
+
+```tsx
+import { useSearch } from '@tanstack/react-router'
+
+function GlobalSearch() {
+  // Returns union of all routes' search params — no runtime error if route doesn't match
+  const search = useSearch({ strict: false })
+  return <span>Query: {search.q ?? ''}</span>
+}
+```
+
+## Code-Split Files: `getRouteApi`
+
+Use `getRouteApi` instead of importing `Route` to avoid pulling route config into the lazy chunk:
+
+```tsx
+// src/routes/posts.lazy.tsx
+import { createLazyFileRoute, getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/posts')
+
+export const Route = createLazyFileRoute('/posts')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const data = routeApi.useLoaderData()
+  const { page } = routeApi.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+## TypeScript Performance
+
+### Use Object Syntax for `addChildren` in Large Route Trees
+
+```tsx
+// SLOWER — tuple syntax
+const routeTree = rootRoute.addChildren([
+  postsRoute.addChildren([postRoute, postsIndexRoute]),
+  indexRoute,
+])
+
+// FASTER — object syntax (TS checks objects faster than large tuples)
+const routeTree = rootRoute.addChildren({
+  postsRoute: postsRoute.addChildren({ postRoute, postsIndexRoute }),
+  indexRoute,
+})
+```
+
+With file-based routing the route tree is generated, so this is handled for you.
+
+### Avoid Returning Unused Inferred Types from Loaders
+
+When using external caches like TanStack Query, don't let the router infer complex return types you never consume:
+
+```tsx
+// SLOWER — TS infers the full ensureQueryData return type into the route tree
+export const Route = createFileRoute('/posts/$postId')({
+  loader: ({ context: { queryClient }, params: { postId } }) =>
+    queryClient.ensureQueryData(postQueryOptions(postId)),
+  component: PostComponent,
+})
+
+// FASTER — void return, inference stays out of the route tree
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ context: { queryClient }, params: { postId } }) => {
+    await queryClient.ensureQueryData(postQueryOptions(postId))
+  },
+  component: PostComponent,
+})
+```
+
+### `as const satisfies` for Link Option Objects
+
+Never use `LinkProps` as a variable type — it's an enormous union:
+
+```tsx
+import type { LinkProps, RegisteredRouter } from '@tanstack/react-router'
+
+// WRONG — LinkProps is a massive union, extremely slow TS check
+const wrongProps: LinkProps = { to: '/posts' }
+
+// CORRECT — infer a precise type, validate against LinkProps
+const goodProps = { to: '/posts' } as const satisfies LinkProps
+
+// EVEN BETTER — narrow LinkProps with generic params
+const narrowedProps = {
+  to: '/posts',
+} as const satisfies LinkProps<RegisteredRouter, string, '/posts'>
+```
+
+### Type-Safe Link Option Arrays
+
+```tsx
+import type { LinkProps } from '@tanstack/react-router'
+
+export const navLinks = [
+  { to: '/posts' },
+  { to: '/posts/$postId', params: { postId: '1' } },
+] as const satisfies ReadonlyArray<LinkProps>
+
+// Use the precise inferred type, not LinkProps directly
+export type NavLink = (typeof navLinks)[number]
+```
+
+## Type Utilities for Generic Components
+
+### `ValidateLinkOptions` — Type-Safe Link Props in Custom Components
+
+```tsx
+import {
+  Link,
+  type RegisteredRouter,
+  type ValidateLinkOptions,
+} from '@tanstack/react-router'
+
+interface NavItemProps<
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+> {
+  label: string
+  linkOptions: ValidateLinkOptions<TRouter, TOptions>
+}
+
+export function NavItem<TRouter extends RegisteredRouter, TOptions>(
+  props: NavItemProps<TRouter, TOptions>,
+): React.ReactNode
+export function NavItem(props: NavItemProps): React.ReactNode {
+  return (
+    <li>
+      <Link {...props.linkOptions}>{props.label}</Link>
+    </li>
+  )
+}
+
+// Usage — fully type-safe
+<NavItem label="Posts" linkOptions={{ to: '/posts' }} />
+<NavItem label="Post" linkOptions={{ to: '/posts/$postId', params: { postId: '1' } }} />
+```
+
+### `ValidateNavigateOptions` — Type-Safe Navigate in Utilities
+
+```tsx
+import {
+  useNavigate,
+  type RegisteredRouter,
+  type ValidateNavigateOptions,
+} from '@tanstack/react-router'
+
+export function useDelayedNavigate<
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+>(
+  options: ValidateNavigateOptions<TRouter, TOptions>,
+  delayMs: number,
+): () => void
+export function useDelayedNavigate(
+  options: ValidateNavigateOptions,
+  delayMs: number,
+): () => void {
+  const navigate = useNavigate()
+  return () => {
+    setTimeout(() => navigate(options), delayMs)
+  }
+}
+
+// Usage — type-safe
+const go = useDelayedNavigate(
+  { to: '/posts/$postId', params: { postId: '1' } },
+  500,
+)
+```
+
+### `ValidateRedirectOptions` — Type-Safe Redirect in Utilities
+
+```tsx
+import {
+  redirect,
+  type RegisteredRouter,
+  type ValidateRedirectOptions,
+} from '@tanstack/react-router'
+
+export async function fetchOrRedirect<
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+>(
+  url: string,
+  redirectOptions: ValidateRedirectOptions<TRouter, TOptions>,
+): Promise<unknown>
+export async function fetchOrRedirect(
+  url: string,
+  redirectOptions: ValidateRedirectOptions,
+): Promise<unknown> {
+  const response = await fetch(url)
+  if (!response.ok && response.status === 401) throw redirect(redirectOptions)
+  return response.json()
+}
+```
+
+### Render Props for Maximum Performance
+
+Instead of accepting `LinkProps`, invert control so `Link` is narrowed at the call site:
+
+```tsx
+function Card(props: { title: string; renderLink: () => React.ReactNode }) {
+  return (
+    <div>
+      <h2>{props.title}</h2>
+      {props.renderLink()}
+    </div>
+  )
+}
+
+// Link narrowed to exactly /posts — no union check
+;<Card title="All Posts" renderLink={() => <Link to="/posts">View</Link>} />
+```
+
+## Render Optimizations
+
+### Fine-Grained Selectors with `select`
+
+```tsx
+function PostTitle() {
+  // Only re-renders when page changes, not when other search params change
+  const page = Route.useSearch({ select: ({ page }) => page })
+  return <span>Page {page}</span>
+}
+```
+
+### Structural Sharing
+
+Preserve referential identity across re-renders for search params:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  defaultStructuralSharing: true, // Enable globally
+})
+
+// Or per-hook
+const result = Route.useSearch({
+  select: (search) => ({ foo: search.foo, label: `Page ${search.foo}` }),
+  structuralSharing: true,
+})
+```
+
+Structural sharing only works with JSON-compatible data. TypeScript will error if you return class instances with `structuralSharing: true`.
+
+## Common Mistakes
+
+### 1. CRITICAL: Adding type annotations or casts to inferred values
+
+```tsx
+// WRONG — casting masks real type errors
+const search = useSearch({ from: '/posts' }) as { page: number }
+
+// WRONG — unnecessary annotation
+const params: { postId: string } = useParams({ from: '/posts/$postId' })
+
+// WRONG — generic param on hook
+const data = useLoaderData<{ posts: Post[] }>({ from: '/posts' })
+
+// CORRECT — let inference work
+const search = useSearch({ from: '/posts' })
+const params = useParams({ from: '/posts/$postId' })
+const data = useLoaderData({ from: '/posts' })
+```
+
+### 2. HIGH: Using un-narrowed `LinkProps` type
+
+```tsx
+// WRONG — LinkProps is a massive union, causes severe TS slowdown
+const myProps: LinkProps = { to: '/posts' }
+
+// CORRECT — use as const satisfies for precise inference
+const myProps = { to: '/posts' } as const satisfies LinkProps
+```
+
+### 3. HIGH: Not narrowing `Link`/`useNavigate` with `from`
+
+```tsx
+// WRONG — search is a union of ALL routes, TS check grows with route count
+<Link to=".." search={{ page: 0 }} />
+
+// CORRECT — narrowed, fast check
+<Link from={Route.fullPath} to=".." search={{ page: 0 }} />
+```
+
+### 4. CRITICAL (cross-skill): Missing router type registration
+
+```tsx
+// WRONG — Link/useNavigate have no autocomplete, all paths are untyped strings
+const router = createRouter({ routeTree })
+// (no declare module)
+
+// CORRECT — always register
+const router = createRouter({ routeTree })
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+
+### 5. CRITICAL (cross-skill): Generating Next.js or Remix patterns
+
+```tsx
+// WRONG — these are NOT TanStack Router APIs
+export async function getServerSideProps() { ... }
+export async function loader({ request }) { ... } // Remix-style
+const [searchParams, setSearchParams] = useSearchParams() // React Router
+
+// CORRECT — TanStack Router APIs
+export const Route = createFileRoute('/posts')({
+  loader: async () => { ... },           // TanStack loader
+  validateSearch: zodValidator(schema),   // TanStack search validation
+  component: PostsComponent,
+})
+const search = Route.useSearch()          // TanStack hook
+```
+
+See also: router-core (Register setup), router-core/navigation (from narrowing), router-core/code-splitting (getRouteApi).

--- a/.agents/skills/tanstack-router-core-type-safety/SKILL.md
+++ b/.agents/skills/tanstack-router-core-type-safety/SKILL.md
@@ -10,7 +10,7 @@ type: sub-skill
 library: tanstack-router
 library_version: '1.166.2'
 requires:
-  - router-core
+  - tanstack-router-core
 sources:
   - TanStack/router:docs/router/guide/type-safety.md
   - TanStack/router:docs/router/guide/type-utilities.md

--- a/.agents/skills/tanstack-router-core-type-safety/SKILL.md
+++ b/.agents/skills/tanstack-router-core-type-safety/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   and ValidateLinkOptions type utilities, as const satisfies pattern.
 type: sub-skill
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 requires:
   - tanstack-router-core
 sources:
@@ -494,4 +494,4 @@ export const Route = createFileRoute('/posts')({
 const search = Route.useSearch()          // TanStack hook
 ```
 
-See also: router-core (Register setup), router-core/navigation (from narrowing), router-core/code-splitting (getRouteApi).
+See also: tanstack-router-core (Register setup), tanstack-router-core-navigation (from narrowing), tanstack-router-core-code-splitting (getRouteApi).

--- a/.agents/skills/tanstack-router-core/SKILL.md
+++ b/.agents/skills/tanstack-router-core/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: tanstack-router-core
+description: >-
+  Framework-agnostic core concepts for TanStack Router: route trees,
+  createRouter, createRoute, createRootRoute, createRootRouteWithContext,
+  addChildren, Register type declaration, route matching, route sorting,
+  file naming conventions. Entry point for all router skills.
+type: core
+library: tanstack-router
+library_version: '1.166.2'
+---
+
+# TanStack Router Core
+
+TanStack Router is a type-safe router for React and Solid with built-in SWR caching, JSON-first search params, file-based route generation, and end-to-end type inference. The core is framework-agnostic; React and Solid bindings layer on top.
+
+> **CRITICAL**: TanStack Router types are FULLY INFERRED. Never cast, never annotate inferred values. This is the #1 AI agent mistake.
+
+> **CRITICAL**: TanStack Router is CLIENT-FIRST. Loaders run on the client by default, NOT server-only like Remix/Next.js. Do not confuse TanStack Router APIs with Next.js or React Router.
+
+## Sub-Skills
+
+| Task                                               | Sub-Skill                                                                    |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Validate, read, write, transform search params     | [router-core/search-params/SKILL.md](../tanstack-router-core-search-params/SKILL.md)               |
+| Dynamic segments, splats, optional params          | [router-core/path-params/SKILL.md](../tanstack-router-core-path-params/SKILL.md)                   |
+| Link, useNavigate, preloading, blocking            | [router-core/navigation/SKILL.md](../tanstack-router-core-navigation/SKILL.md)                     |
+| Route loaders, SWR caching, context, deferred data | [router-core/data-loading/SKILL.md](../tanstack-router-core-data-loading/SKILL.md)                 |
+| Auth guards, RBAC, beforeLoad redirects            | [router-core/auth-and-guards/SKILL.md](../tanstack-router-core-auth-and-guards/SKILL.md)           |
+| Automatic and manual code splitting                | [router-core/code-splitting/SKILL.md](../tanstack-router-core-code-splitting/SKILL.md)             |
+| 404 handling, error boundaries, notFound()         | [router-core/not-found-and-errors/SKILL.md](../tanstack-router-core-not-found-and-errors/SKILL.md) |
+| Inference, Register, from narrowing, TS perf       | [router-core/type-safety/SKILL.md](../tanstack-router-core-type-safety/SKILL.md)                   |
+| Streaming/non-streaming SSR, hydration, head mgmt  | [router-core/ssr/SKILL.md](../tanstack-router-core-ssr/SKILL.md)                                   |
+
+## Quick Decision Tree
+
+```
+Need to add/read/write URL query parameters?
+  → router-core/search-params
+
+Need dynamic URL segments like /posts/$postId?
+  → router-core/path-params
+
+Need to create links or navigate programmatically?
+  → router-core/navigation
+
+Need to fetch data for a route?
+  Is it client-side only or client+server?
+    → router-core/data-loading
+  Using TanStack Query as external cache?
+    → compositions/router-query (separate skill)
+
+Need to protect routes behind auth?
+  → router-core/auth-and-guards
+
+Need to reduce bundle size per route?
+  → router-core/code-splitting
+
+Need custom 404 or error handling?
+  → router-core/not-found-and-errors
+
+Having TypeScript issues or performance problems?
+  → router-core/type-safety
+
+Need server-side rendering?
+  → router-core/ssr
+```
+
+## Minimal Working Example
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRoute, Outlet } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+})
+```
+
+```tsx
+// src/routes/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  component: () => <h1>Home</h1>,
+})
+```
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({ routeTree })
+
+// REQUIRED for type safety — without this, Link/useNavigate have no autocomplete
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+export default router
+```
+
+```tsx
+// src/main.tsx
+import { RouterProvider } from '@tanstack/react-router'
+import router from './router'
+
+function App() {
+  return <RouterProvider router={router} />
+}
+```
+
+## Common Mistakes
+
+### HIGH: createFileRoute path string must match the file path
+
+The Vite plugin manages the path string in `createFileRoute`. Do not change it manually — it must match the file's location under `src/routes/`:
+
+```tsx
+// File: src/routes/posts/$postId.tsx
+export const Route = createFileRoute('/posts/$postId')({
+  // ✅ matches file path
+  component: PostPage,
+})
+
+export const Route = createFileRoute('/post/$postId')({
+  // ❌ silent mismatch
+  component: PostPage,
+})
+```
+
+The plugin auto-generates this string. If you rename a route file, the plugin updates it. Never edit the path string by hand.
+
+## Version Note
+
+This skill targets `@tanstack/router-core` v1.166.2 and `@tanstack/react-router` v1.166.2. APIs are stable. Splat routes use `$` (not `*`); the `*` compat alias will be removed in v2.

--- a/.agents/skills/tanstack-router-core/SKILL.md
+++ b/.agents/skills/tanstack-router-core/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   file naming conventions. Entry point for all router skills.
 type: core
 library: tanstack-router
-library_version: '1.166.2'
+library_version: '1.168.23'
 ---
 
 # TanStack Router Core
@@ -22,48 +22,48 @@ TanStack Router is a type-safe router for React and Solid with built-in SWR cach
 
 | Task                                               | Sub-Skill                                                                    |
 | -------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Validate, read, write, transform search params     | [router-core/search-params/SKILL.md](../tanstack-router-core-search-params/SKILL.md)               |
-| Dynamic segments, splats, optional params          | [router-core/path-params/SKILL.md](../tanstack-router-core-path-params/SKILL.md)                   |
-| Link, useNavigate, preloading, blocking            | [router-core/navigation/SKILL.md](../tanstack-router-core-navigation/SKILL.md)                     |
-| Route loaders, SWR caching, context, deferred data | [router-core/data-loading/SKILL.md](../tanstack-router-core-data-loading/SKILL.md)                 |
-| Auth guards, RBAC, beforeLoad redirects            | [router-core/auth-and-guards/SKILL.md](../tanstack-router-core-auth-and-guards/SKILL.md)           |
-| Automatic and manual code splitting                | [router-core/code-splitting/SKILL.md](../tanstack-router-core-code-splitting/SKILL.md)             |
-| 404 handling, error boundaries, notFound()         | [router-core/not-found-and-errors/SKILL.md](../tanstack-router-core-not-found-and-errors/SKILL.md) |
-| Inference, Register, from narrowing, TS perf       | [router-core/type-safety/SKILL.md](../tanstack-router-core-type-safety/SKILL.md)                   |
-| Streaming/non-streaming SSR, hydration, head mgmt  | [router-core/ssr/SKILL.md](../tanstack-router-core-ssr/SKILL.md)                                   |
+| Validate, read, write, transform search params     | [tanstack-router-core-search-params/SKILL.md](../tanstack-router-core-search-params/SKILL.md)               |
+| Dynamic segments, splats, optional params          | [tanstack-router-core-path-params/SKILL.md](../tanstack-router-core-path-params/SKILL.md)                   |
+| Link, useNavigate, preloading, blocking            | [tanstack-router-core-navigation/SKILL.md](../tanstack-router-core-navigation/SKILL.md)                     |
+| Route loaders, SWR caching, context, deferred data | [tanstack-router-core-data-loading/SKILL.md](../tanstack-router-core-data-loading/SKILL.md)                 |
+| Auth guards, RBAC, beforeLoad redirects            | [tanstack-router-core-auth-and-guards/SKILL.md](../tanstack-router-core-auth-and-guards/SKILL.md)           |
+| Automatic and manual code splitting                | [tanstack-router-core-code-splitting/SKILL.md](../tanstack-router-core-code-splitting/SKILL.md)             |
+| 404 handling, error boundaries, notFound()         | [tanstack-router-core-not-found-and-errors/SKILL.md](../tanstack-router-core-not-found-and-errors/SKILL.md) |
+| Inference, Register, from narrowing, TS perf       | [tanstack-router-core-type-safety/SKILL.md](../tanstack-router-core-type-safety/SKILL.md)                   |
+| Streaming/non-streaming SSR, hydration, head mgmt  | [tanstack-router-core-ssr/SKILL.md](../tanstack-router-core-ssr/SKILL.md)                                   |
 
 ## Quick Decision Tree
 
 ```
 Need to add/read/write URL query parameters?
-  → router-core/search-params
+  → tanstack-router-core-search-params
 
 Need dynamic URL segments like /posts/$postId?
-  → router-core/path-params
+  → tanstack-router-core-path-params
 
 Need to create links or navigate programmatically?
-  → router-core/navigation
+  → tanstack-router-core-navigation
 
 Need to fetch data for a route?
   Is it client-side only or client+server?
-    → router-core/data-loading
+    → tanstack-router-core-data-loading
   Using TanStack Query as external cache?
     → compositions/router-query (separate skill)
 
 Need to protect routes behind auth?
-  → router-core/auth-and-guards
+  → tanstack-router-core-auth-and-guards
 
 Need to reduce bundle size per route?
-  → router-core/code-splitting
+  → tanstack-router-core-code-splitting
 
 Need custom 404 or error handling?
-  → router-core/not-found-and-errors
+  → tanstack-router-core-not-found-and-errors
 
 Having TypeScript issues or performance problems?
-  → router-core/type-safety
+  → tanstack-router-core-type-safety
 
 Need server-side rendering?
-  → router-core/ssr
+  → tanstack-router-core-ssr
 ```
 
 ## Minimal Working Example
@@ -136,4 +136,4 @@ The plugin auto-generates this string. If you rename a route file, the plugin up
 
 ## Version Note
 
-This skill targets `@tanstack/router-core` v1.166.2 and `@tanstack/react-router` v1.166.2. APIs are stable. Splat routes use `$` (not `*`); the `*` compat alias will be removed in v2.
+This skill targets the repo lockfile versions: `@tanstack/router-core` v1.168.15 and `@tanstack/react-router` v1.168.23. APIs are stable. Splat routes use `$` (not `*`); the `*` compat alias will be removed in v2.

--- a/.agents/skills/tanstack-start-core-deployment/SKILL.md
+++ b/.agents/skills/tanstack-start-core-deployment/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: tanstack-start-core-deployment
+description: >-
+  Deploy to Cloudflare Workers, Netlify, Vercel, Node.js/Docker,
+  Bun, Railway. Selective SSR (ssr option per route), SPA mode,
+  static prerendering, ISR with Cache-Control headers, SEO and
+  head management.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/hosting.md
+  - TanStack/router:docs/start/framework/react/guide/selective-ssr.md
+  - TanStack/router:docs/start/framework/react/guide/static-prerendering.md
+  - TanStack/router:docs/start/framework/react/guide/seo.md
+---
+
+# Deployment and Rendering
+
+TanStack Start deploys to any hosting provider via Vite and Nitro. This skill covers hosting setup, SSR configuration, prerendering, and SEO.
+
+## Hosting Providers
+
+### Cloudflare Workers
+
+```bash
+pnpm add -D @cloudflare/vite-plugin wrangler
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import { cloudflare } from '@cloudflare/vite-plugin'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    cloudflare({ viteEnvironment: { name: 'ssr' } }),
+    tanstackStart(),
+    viteReact(),
+  ],
+})
+```
+
+```jsonc
+// wrangler.jsonc
+{
+  "name": "my-app",
+  "compatibility_date": "2025-09-02",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "@tanstack/react-start/server-entry",
+}
+```
+
+Deploy: `npx wrangler login && pnpm run deploy`
+
+### Netlify
+
+```bash
+pnpm add -D @netlify/vite-plugin-tanstack-start
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import netlify from '@netlify/vite-plugin-tanstack-start'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [tanstackStart(), netlify(), viteReact()],
+})
+```
+
+Deploy: `npx netlify deploy`
+
+### Nitro (Vercel, Railway, Node.js, Docker)
+
+```bash
+npm install nitro@npm:nitro-nightly@latest
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import { nitro } from 'nitro/vite'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [tanstackStart(), nitro(), viteReact()],
+})
+```
+
+Build and start: `npm run build && node .output/server/index.mjs`
+
+### Bun
+
+Bun deployment requires React 19. For React 18, use Node.js deployment.
+
+```ts
+// vite.config.ts — add bun preset to nitro
+plugins: [tanstackStart(), nitro({ preset: 'bun' }), viteReact()]
+```
+
+## Selective SSR
+
+Control SSR per route with the `ssr` property.
+
+### `ssr: true` (default)
+
+Runs `beforeLoad` and `loader` on server, renders component on server:
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  ssr: true, // default
+  loader: () => fetchPost(), // runs on server during SSR
+  component: PostPage, // rendered on server
+})
+```
+
+### `ssr: false`
+
+Disables server execution of `beforeLoad`/`loader` and server rendering:
+
+```tsx
+export const Route = createFileRoute('/dashboard')({
+  ssr: false,
+  loader: () => fetchDashboard(), // runs on client only
+  component: DashboardPage, // rendered on client only
+})
+```
+
+### `ssr: 'data-only'`
+
+Runs `beforeLoad`/`loader` on server but renders component on client only:
+
+```tsx
+export const Route = createFileRoute('/canvas')({
+  ssr: 'data-only',
+  loader: () => fetchCanvasData(), // runs on server
+  component: CanvasPage, // rendered on client only
+})
+```
+
+### Functional Form
+
+Decide SSR at runtime based on params/search:
+
+```tsx
+export const Route = createFileRoute('/docs/$docType/$docId')({
+  ssr: ({ params }) => {
+    if (params.status === 'success' && params.value.docType === 'sheet') {
+      return false
+    }
+  },
+})
+```
+
+### SSR Inheritance
+
+Children inherit parent SSR config and can only be MORE restrictive:
+
+- `true` → `data-only` or `false` (allowed)
+- `false` → `true` (NOT allowed — parent `false` wins)
+
+### Default SSR
+
+Change the default for all routes in `src/start.ts`:
+
+```tsx
+import { createStart } from '@tanstack/react-start'
+
+export const startInstance = createStart(() => ({
+  defaultSsr: false,
+}))
+```
+
+## Static Prerendering
+
+Generate static HTML at build time:
+
+```ts
+// vite.config.ts
+tanstackStart({
+  prerender: {
+    enabled: true,
+    crawlLinks: true,
+    concurrency: 14,
+    failOnError: true,
+  },
+})
+```
+
+Static routes are auto-discovered. Dynamic routes (e.g. `/users/$userId`) require `crawlLinks` or explicit `pages` config.
+
+## SEO and Head Management
+
+### Basic Meta Tags
+
+```tsx
+export const Route = createFileRoute('/')({
+  head: () => ({
+    meta: [
+      { title: 'My App - Home' },
+      { name: 'description', content: 'Welcome to My App' },
+    ],
+  }),
+})
+```
+
+### Dynamic Meta from Loader Data
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => fetchPost(params.postId),
+  head: ({ loaderData }) => ({
+    meta: [
+      { title: loaderData.title },
+      { name: 'description', content: loaderData.excerpt },
+      { property: 'og:title', content: loaderData.title },
+      { property: 'og:image', content: loaderData.coverImage },
+    ],
+  }),
+})
+```
+
+### Structured Data (JSON-LD)
+
+```tsx
+head: ({ loaderData }) => ({
+  scripts: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: loaderData.title,
+      }),
+    },
+  ],
+})
+```
+
+### Dynamic Sitemap via Server Route
+
+```ts
+// src/routes/sitemap[.]xml.ts
+export const Route = createFileRoute('/sitemap.xml')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const posts = await fetchAllPosts()
+        const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ${posts.map((p) => `<url><loc>https://myapp.com/posts/${p.id}</loc></url>`).join('')}
+</urlset>`
+        return new Response(sitemap, {
+          headers: { 'Content-Type': 'application/xml' },
+        })
+      },
+    },
+  },
+})
+```
+
+## Common Mistakes
+
+### 1. HIGH: Missing nodejs_compat flag for Cloudflare Workers
+
+```jsonc
+// WRONG — Node.js APIs fail at runtime
+{ "compatibility_flags": [] }
+
+// CORRECT
+{ "compatibility_flags": ["nodejs_compat"] }
+```
+
+### 2. MEDIUM: Bun deployment with React 18
+
+Bun-specific deployment only works with React 19. Use Node.js deployment for React 18.
+
+### 3. MEDIUM: Child route loosening parent SSR config
+
+```tsx
+// Parent sets ssr: false
+// WRONG — child cannot upgrade to ssr: true
+const parentRoute = createFileRoute('/dashboard')({ ssr: false })
+const childRoute = createFileRoute('/dashboard/stats')({
+  ssr: true, // IGNORED — parent false wins
+})
+
+// CORRECT — children can only be MORE restrictive
+const parentRoute = createFileRoute('/dashboard')({ ssr: 'data-only' })
+const childRoute = createFileRoute('/dashboard/stats')({
+  ssr: false, // OK — more restrictive than parent
+})
+```
+
+## Cross-References
+
+- [start-core/server-routes](../tanstack-start-core-server-routes/SKILL.md) — API endpoints for sitemaps, robots.txt
+- [start-core/execution-model](../tanstack-start-core-execution-model/SKILL.md) — SSR affects where code runs

--- a/.agents/skills/tanstack-start-core-deployment/SKILL.md
+++ b/.agents/skills/tanstack-start-core-deployment/SKILL.md
@@ -153,7 +153,7 @@ Decide SSR at runtime based on params/search:
 ```tsx
 export const Route = createFileRoute('/docs/$docType/$docId')({
   ssr: ({ params }) => {
-    if (params.status === 'success' && params.value.docType === 'sheet') {
+    if (params.docType === 'sheet') {
       return false
     }
   },

--- a/.agents/skills/tanstack-start-core-deployment/SKILL.md
+++ b/.agents/skills/tanstack-start-core-deployment/SKILL.md
@@ -80,7 +80,7 @@ Deploy: `npx netlify deploy`
 ### Nitro (Vercel, Railway, Node.js, Docker)
 
 ```bash
-npm install nitro@npm:nitro-nightly@latest
+pnpm add -D nitro
 ```
 
 ```ts

--- a/.agents/skills/tanstack-start-core-deployment/SKILL.md
+++ b/.agents/skills/tanstack-start-core-deployment/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   head management.
 type: sub-skill
 library: tanstack-start
-library_version: '1.166.2'
+library_version: '1.167.42'
 requires:
   - tanstack-start-core
 sources:
@@ -95,7 +95,7 @@ export default defineConfig({
 })
 ```
 
-Build and start: `npm run build && node .output/server/index.mjs`
+Build and start from the repo root: `pnpm --filter web build && node apps/web/.output/server/index.mjs`
 
 ### Bun
 
@@ -302,5 +302,5 @@ const childRoute = createFileRoute('/dashboard/stats')({
 
 ## Cross-References
 
-- [start-core/server-routes](../tanstack-start-core-server-routes/SKILL.md) — API endpoints for sitemaps, robots.txt
-- [start-core/execution-model](../tanstack-start-core-execution-model/SKILL.md) — SSR affects where code runs
+- [tanstack-start-core-server-routes](../tanstack-start-core-server-routes/SKILL.md) — API endpoints for sitemaps, robots.txt
+- [tanstack-start-core-execution-model](../tanstack-start-core-execution-model/SKILL.md) — SSR affects where code runs

--- a/.agents/skills/tanstack-start-core-deployment/SKILL.md
+++ b/.agents/skills/tanstack-start-core-deployment/SKILL.md
@@ -9,7 +9,7 @@ type: sub-skill
 library: tanstack-start
 library_version: '1.166.2'
 requires:
-  - start-core
+  - tanstack-start-core
 sources:
   - TanStack/router:docs/start/framework/react/guide/hosting.md
   - TanStack/router:docs/start/framework/react/guide/selective-ssr.md

--- a/.agents/skills/tanstack-start-core-execution-model/SKILL.md
+++ b/.agents/skills/tanstack-start-core-execution-model/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   safety (VITE_ prefix, process.env).
 type: sub-skill
 library: tanstack-start
-library_version: '1.166.2'
+library_version: '1.167.42'
 requires:
   - tanstack-start-core
 sources:
@@ -298,5 +298,5 @@ function CurrentTime() {
 
 ## Cross-References
 
-- [start-core/server-functions](../tanstack-start-core-server-functions/SKILL.md) — the primary server boundary
-- [start-core/deployment](../tanstack-start-core-deployment/SKILL.md) — deployment target affects execution
+- [tanstack-start-core-server-functions](../tanstack-start-core-server-functions/SKILL.md) — the primary server boundary
+- [tanstack-start-core-deployment](../tanstack-start-core-deployment/SKILL.md) — deployment target affects execution

--- a/.agents/skills/tanstack-start-core-execution-model/SKILL.md
+++ b/.agents/skills/tanstack-start-core-execution-model/SKILL.md
@@ -10,7 +10,7 @@ type: sub-skill
 library: tanstack-start
 library_version: '1.166.2'
 requires:
-  - start-core
+  - tanstack-start-core
 sources:
   - TanStack/router:docs/start/framework/react/guide/execution-model.md
   - TanStack/router:docs/start/framework/react/guide/environment-variables.md

--- a/.agents/skills/tanstack-start-core-execution-model/SKILL.md
+++ b/.agents/skills/tanstack-start-core-execution-model/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: tanstack-start-core-execution-model
+description: >-
+  Isomorphic-by-default principle, environment boundary functions
+  (createServerFn, createServerOnlyFn, createClientOnlyFn,
+  createIsomorphicFn), ClientOnly component, useHydrated hook,
+  import protection, dead code elimination, environment variable
+  safety (VITE_ prefix, process.env).
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/execution-model.md
+  - TanStack/router:docs/start/framework/react/guide/environment-variables.md
+---
+
+# Execution Model
+
+Understanding where code runs is fundamental to TanStack Start. This skill covers the isomorphic execution model and how to control environment boundaries.
+
+> **CRITICAL**: ALL code in TanStack Start is isomorphic by default — it runs in BOTH server and client bundles. Route loaders run on BOTH server (during SSR) AND client (during navigation). Server-only operations MUST use `createServerFn`.
+> **CRITICAL**: Module-level `process.env` access runs in both environments. Secret values leak into the client bundle. Access secrets ONLY inside `createServerFn` or `createServerOnlyFn`.
+> **CRITICAL**: `VITE_` prefixed environment variables are exposed to the client bundle. Server secrets must NOT have the `VITE_` prefix.
+
+## Execution Control APIs
+
+| API                      | Use Case                  | Client Behavior           | Server Behavior       |
+| ------------------------ | ------------------------- | ------------------------- | --------------------- |
+| `createServerFn()`       | RPC calls, data mutations | Network request to server | Direct execution      |
+| `createServerOnlyFn(fn)` | Utility functions         | Throws error              | Direct execution      |
+| `createClientOnlyFn(fn)` | Browser utilities         | Direct execution          | Throws error          |
+| `createIsomorphicFn()`   | Different impl per env    | Uses `.client()` impl     | Uses `.server()` impl |
+| `<ClientOnly>`           | Browser-only components   | Renders children          | Renders fallback      |
+| `useHydrated()`          | Hydration-dependent logic | `true` after hydration    | `false`               |
+
+## Server-Only Execution
+
+### createServerFn (RPC pattern)
+
+The primary way to run server-only code. On the client, calls become fetch requests:
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createServerFn } from '@tanstack/react-start'
+
+const fetchUser = createServerFn().handler(async () => {
+  const secret = process.env.API_SECRET // safe — server only
+  return await db.users.find()
+})
+
+// Client calls this via network request
+const user = await fetchUser()
+```
+
+### createServerOnlyFn (throws on client)
+
+For utility functions that must never run on client:
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createServerOnlyFn } from '@tanstack/react-start'
+
+const getSecret = createServerOnlyFn(() => process.env.DATABASE_URL)
+
+// Server: returns the value
+// Client: THROWS an error
+```
+
+## Client-Only Execution
+
+### createClientOnlyFn
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createClientOnlyFn } from '@tanstack/react-start'
+
+const saveToStorage = createClientOnlyFn((key: string, value: string) => {
+  localStorage.setItem(key, value)
+})
+```
+
+### ClientOnly Component
+
+```tsx
+// Use @tanstack/<framework>-router for your framework (react, solid, vue)
+import { ClientOnly } from '@tanstack/react-router'
+
+function Analytics() {
+  return (
+    <ClientOnly fallback={null}>
+      <GoogleAnalyticsScript />
+    </ClientOnly>
+  )
+}
+```
+
+### useHydrated Hook
+
+```tsx
+// Use @tanstack/<framework>-router for your framework (react, solid, vue)
+import { useHydrated } from '@tanstack/react-router'
+
+function TimeZoneDisplay() {
+  const hydrated = useHydrated()
+  const timeZone = hydrated
+    ? Intl.DateTimeFormat().resolvedOptions().timeZone
+    : 'UTC'
+
+  return <div>Your timezone: {timeZone}</div>
+}
+```
+
+Behavior: SSR → `false`, first client render → `false`, after hydration → `true` (stays `true`).
+
+## Environment-Specific Implementations
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createIsomorphicFn } from '@tanstack/react-start'
+
+const getDeviceInfo = createIsomorphicFn()
+  .server(() => ({ type: 'server', platform: process.platform }))
+  .client(() => ({ type: 'client', userAgent: navigator.userAgent }))
+```
+
+## Environment Variables
+
+### Server-Side (inside createServerFn)
+
+Access any variable via `process.env`:
+
+```tsx
+const connectDb = createServerFn().handler(async () => {
+  const url = process.env.DATABASE_URL // no prefix needed
+  return createConnection(url)
+})
+```
+
+### Client-Side (components)
+
+Only `VITE_` prefixed variables are available:
+
+```tsx
+// Framework-specific component type (React.ReactNode, JSX.Element, etc.)
+function ApiProvider({ children }: { children: React.ReactNode }) {
+  const apiUrl = import.meta.env.VITE_API_URL // available
+  // import.meta.env.DATABASE_URL → undefined (security)
+  return (
+    <ApiContext.Provider value={{ apiUrl }}>{children}</ApiContext.Provider>
+  )
+}
+```
+
+### Runtime Client Variables
+
+If you need server-side variables on the client without `VITE_` prefix, pass them through a server function:
+
+```tsx
+const getRuntimeVar = createServerFn({ method: 'GET' }).handler(() => {
+  return process.env.MY_RUNTIME_VAR
+})
+
+export const Route = createFileRoute('/')({
+  loader: async () => {
+    const foo = await getRuntimeVar()
+    return { foo }
+  },
+  component: () => {
+    const { foo } = Route.useLoaderData()
+    return <div>{foo}</div>
+  },
+})
+```
+
+### Type Safety for Environment Variables
+
+```tsx
+// src/env.d.ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME: string
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      readonly DATABASE_URL: string
+      readonly JWT_SECRET: string
+    }
+  }
+}
+
+export {}
+```
+
+## Common Mistakes
+
+### 1. CRITICAL: Assuming loaders are server-only
+
+```tsx
+// WRONG — loader runs on BOTH server and client
+export const Route = createFileRoute('/dashboard')({
+  loader: async () => {
+    const secret = process.env.API_SECRET // LEAKED to client
+    return fetch(`https://api.example.com/data`, {
+      headers: { Authorization: secret },
+    })
+  },
+})
+
+// CORRECT — use createServerFn
+const getData = createServerFn({ method: 'GET' }).handler(async () => {
+  const secret = process.env.API_SECRET
+  return fetch(`https://api.example.com/data`, {
+    headers: { Authorization: secret },
+  })
+})
+
+export const Route = createFileRoute('/dashboard')({
+  loader: () => getData(),
+})
+```
+
+### 2. CRITICAL: Exposing secrets via module-level process.env
+
+```tsx
+// WRONG — runs in both environments, value in client bundle
+const apiKey = process.env.SECRET_KEY
+export function fetchData() {
+  /* uses apiKey */
+}
+
+// CORRECT — access inside server function only
+const fetchData = createServerFn({ method: 'GET' }).handler(async () => {
+  const apiKey = process.env.SECRET_KEY
+  return fetch(url, { headers: { Authorization: apiKey } })
+})
+```
+
+### 3. CRITICAL: Using VITE\_ prefix for server secrets
+
+```bash
+# WRONG — exposed to client bundle
+VITE_SECRET_API_KEY=sk_live_xxx
+
+# CORRECT — no prefix for server secrets
+SECRET_API_KEY=sk_live_xxx
+
+# CORRECT — VITE_ only for public client values
+VITE_APP_NAME=My App
+```
+
+### 4. HIGH: Hydration mismatches
+
+```tsx
+// WRONG — different content server vs client
+function CurrentTime() {
+  return <div>{new Date().toLocaleString()}</div>
+}
+
+// CORRECT — consistent rendering
+function CurrentTime() {
+  const [time, setTime] = useState<string>()
+  useEffect(() => {
+    setTime(new Date().toLocaleString())
+  }, [])
+  return <div>{time || 'Loading...'}</div>
+}
+```
+
+## Architecture Decision Framework
+
+**Server-Only** (`createServerFn` / `createServerOnlyFn`):
+
+- Sensitive data (env vars, secrets)
+- Database connections, file system
+- External API keys
+
+**Client-Only** (`createClientOnlyFn` / `<ClientOnly>`):
+
+- DOM manipulation, browser APIs
+- localStorage, geolocation
+- Analytics/tracking
+
+**Isomorphic** (default / `createIsomorphicFn`):
+
+- Data formatting, business logic
+- Shared utilities
+- Route loaders (they're isomorphic by nature)
+
+## Cross-References
+
+- [start-core/server-functions](../tanstack-start-core-server-functions/SKILL.md) — the primary server boundary
+- [start-core/deployment](../tanstack-start-core-deployment/SKILL.md) — deployment target affects execution

--- a/.agents/skills/tanstack-start-core-middleware/SKILL.md
+++ b/.agents/skills/tanstack-start-core-middleware/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   enforcement, fetch override precedence.
 type: sub-skill
 library: tanstack-start
-library_version: '1.166.2'
+library_version: '1.167.42'
 requires:
   - tanstack-start-core
   - tanstack-start-core-server-functions
@@ -361,5 +361,5 @@ createMiddleware({ type: 'function' })
 
 ## Cross-References
 
-- [start-core/server-functions](../tanstack-start-core-server-functions/SKILL.md) — what middleware wraps
-- [start-core/server-routes](../tanstack-start-core-server-routes/SKILL.md) — middleware on API endpoints
+- [tanstack-start-core-server-functions](../tanstack-start-core-server-functions/SKILL.md) — what middleware wraps
+- [tanstack-start-core-server-routes](../tanstack-start-core-server-routes/SKILL.md) — middleware on API endpoints

--- a/.agents/skills/tanstack-start-core-middleware/SKILL.md
+++ b/.agents/skills/tanstack-start-core-middleware/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: tanstack-start-core-middleware
+description: >-
+  createMiddleware, request middleware (.server only), server function
+  middleware (.client + .server), context passing via next({ context }),
+  sendContext for client-server transfer, global middleware via
+  createStart in src/start.ts, middleware factories, method order
+  enforcement, fetch override precedence.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+  - start-core/server-functions
+sources:
+  - TanStack/router:docs/start/framework/react/guide/middleware.md
+---
+
+# Middleware
+
+Middleware customizes the behavior of server functions and server routes. It is composable — middleware can depend on other middleware to form a chain.
+
+> **CRITICAL**: TypeScript enforces method order: `middleware()` → `inputValidator()` → `client()` → `server()`. Wrong order causes type errors.
+> **CRITICAL**: Client context sent via `sendContext` is NOT validated by default. If you send dynamic user-generated data, validate it in server-side middleware before use.
+
+## Two Types of Middleware
+
+| Feature           | Request Middleware                           | Server Function Middleware               |
+| ----------------- | -------------------------------------------- | ---------------------------------------- |
+| Scope             | All server requests (SSR, routes, functions) | Server functions only                    |
+| Methods           | `.server()`                                  | `.client()`, `.server()`                 |
+| Input validation  | No                                           | Yes (`.inputValidator()`)                |
+| Client-side logic | No                                           | Yes                                      |
+| Created with      | `createMiddleware()`                         | `createMiddleware({ type: 'function' })` |
+
+Request middleware cannot depend on server function middleware. Server function middleware can depend on both types.
+
+## Request Middleware
+
+Runs on ALL server requests (SSR, server routes, server functions):
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createMiddleware } from '@tanstack/react-start'
+
+const loggingMiddleware = createMiddleware().server(
+  async ({ next, context, request }) => {
+    console.log('Request:', request.url)
+    const result = await next()
+    return result
+  },
+)
+```
+
+## Server Function Middleware
+
+Has both client and server phases:
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createMiddleware } from '@tanstack/react-start'
+
+const authMiddleware = createMiddleware({ type: 'function' })
+  .client(async ({ next }) => {
+    // Runs on client BEFORE the RPC call
+    const result = await next()
+    // Runs on client AFTER the RPC response
+    return result
+  })
+  .server(async ({ next, context }) => {
+    // Runs on server BEFORE the handler
+    const result = await next()
+    // Runs on server AFTER the handler
+    return result
+  })
+```
+
+## Attaching Middleware to Server Functions
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createServerFn } from '@tanstack/react-start'
+
+const fn = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    // context contains data from middleware
+    return { user: context.user }
+  })
+```
+
+## Context Passing via next()
+
+Pass context down the middleware chain:
+
+```tsx
+const authMiddleware = createMiddleware().server(async ({ next, request }) => {
+  const session = await getSession(request.headers)
+  if (!session) throw new Error('Unauthorized')
+
+  return next({
+    context: { session },
+  })
+})
+
+const roleMiddleware = createMiddleware()
+  .middleware([authMiddleware])
+  .server(async ({ next, context }) => {
+    console.log('Session:', context.session) // typed!
+    return next()
+  })
+```
+
+## Sending Context Between Client and Server
+
+### Client → Server (sendContext)
+
+```tsx
+const workspaceMiddleware = createMiddleware({ type: 'function' })
+  .client(async ({ next, context }) => {
+    return next({
+      sendContext: {
+        workspaceId: context.workspaceId,
+      },
+    })
+  })
+  .server(async ({ next, context }) => {
+    // workspaceId available here, but VALIDATE IT
+    console.log('Workspace:', context.workspaceId)
+    return next()
+  })
+```
+
+### Server → Client (sendContext in server)
+
+```tsx
+const serverTimer = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    return next({
+      sendContext: {
+        timeFromServer: new Date(),
+      },
+    })
+  },
+)
+
+const clientLogger = createMiddleware({ type: 'function' })
+  .middleware([serverTimer])
+  .client(async ({ next }) => {
+    const result = await next()
+    console.log('Server time:', result.context.timeFromServer)
+    return result
+  })
+```
+
+## Input Validation in Middleware
+
+```tsx
+import { z } from 'zod'
+import { zodValidator } from '@tanstack/zod-adapter'
+
+const workspaceMiddleware = createMiddleware({ type: 'function' })
+  .inputValidator(zodValidator(z.object({ workspaceId: z.string() })))
+  .server(async ({ next, data }) => {
+    console.log('Workspace:', data.workspaceId)
+    return next()
+  })
+```
+
+## Global Middleware
+
+Create `src/start.ts` to configure global middleware:
+
+```tsx
+// src/start.ts
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createStart, createMiddleware } from '@tanstack/react-start'
+
+const requestLogger = createMiddleware().server(async ({ next, request }) => {
+  console.log(`${request.method} ${request.url}`)
+  return next()
+})
+
+const functionAuth = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    // runs for every server function
+    return next()
+  },
+)
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [requestLogger],
+  functionMiddleware: [functionAuth],
+}))
+```
+
+## Using Middleware with Server Routes
+
+### All handlers in a route
+
+```tsx
+export const Route = createFileRoute('/api/users')({
+  server: {
+    middleware: [authMiddleware],
+    handlers: {
+      GET: async ({ context }) => Response.json(context.user),
+      POST: async ({ request }) => {
+        /* ... */
+      },
+    },
+  },
+})
+```
+
+### Specific handlers only
+
+```tsx
+export const Route = createFileRoute('/api/users')({
+  server: {
+    handlers: ({ createHandlers }) =>
+      createHandlers({
+        GET: async () => Response.json({ public: true }),
+        POST: {
+          middleware: [authMiddleware],
+          handler: async ({ context }) => {
+            return Response.json({ user: context.session.user })
+          },
+        },
+      }),
+  },
+})
+```
+
+## Middleware Factories
+
+Create parameterized middleware for reusable patterns like authorization:
+
+```tsx
+const authMiddleware = createMiddleware().server(async ({ next, request }) => {
+  const session = await auth.getSession({ headers: request.headers })
+  if (!session) throw new Error('Unauthorized')
+  return next({ context: { session } })
+})
+
+type Permissions = Record<string, string[]>
+
+function authorizationMiddleware(permissions: Permissions) {
+  return createMiddleware({ type: 'function' })
+    .middleware([authMiddleware])
+    .server(async ({ next, context }) => {
+      const granted = await auth.hasPermission(context.session, permissions)
+      if (!granted) throw new Error('Forbidden')
+      return next()
+    })
+}
+
+// Usage
+const getClients = createServerFn()
+  .middleware([authorizationMiddleware({ client: ['read'] })])
+  .handler(async () => {
+    return { message: 'The user can read clients.' }
+  })
+```
+
+## Custom Headers and Fetch
+
+### Setting headers from client middleware
+
+```tsx
+const authMiddleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    return next({
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+  },
+)
+```
+
+Headers merge across middleware. Later middleware overrides earlier. Call-site headers override all middleware headers.
+
+### Custom fetch
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import type { CustomFetch } from '@tanstack/react-start'
+
+const loggingMiddleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    const customFetch: CustomFetch = async (url, init) => {
+      console.log('Request:', url)
+      return fetch(url, init)
+    }
+    return next({ fetch: customFetch })
+  },
+)
+```
+
+Fetch precedence (highest to lowest): call site → later middleware → earlier middleware → createStart global → default fetch.
+
+## Common Mistakes
+
+### 1. HIGH: Trusting client sendContext without validation
+
+```tsx
+// WRONG — client can send arbitrary data
+.server(async ({ next, context }) => {
+  await db.query(`SELECT * FROM workspace_${context.workspaceId}`)
+  return next()
+})
+
+// CORRECT — validate before use
+.server(async ({ next, context }) => {
+  const workspaceId = z.string().uuid().parse(context.workspaceId)
+  await db.query('SELECT * FROM workspaces WHERE id = $1', [workspaceId])
+  return next()
+})
+```
+
+### 2. MEDIUM: Confusing request vs server function middleware
+
+Request middleware runs on ALL requests (SSR, routes, functions). Server function middleware runs only for `createServerFn` calls and has `.client()` method.
+
+### 3. HIGH: Browser APIs in .client() crash during SSR
+
+During SSR, `.client()` callbacks run on the server. Browser-only APIs like `localStorage` or `window` will throw `ReferenceError`:
+
+```tsx
+// WRONG — localStorage doesn't exist on the server during SSR
+const middleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    const token = localStorage.getItem('token')
+    return next({ sendContext: { token } })
+  },
+)
+
+// CORRECT — use cookies/headers or guard with typeof window check
+const middleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('token') : null
+    return next({ sendContext: { token } })
+  },
+)
+```
+
+### 4. MEDIUM: Wrong method order
+
+```tsx
+// WRONG — type error
+createMiddleware({ type: 'function' })
+  .server(() => { ... })
+  .client(() => { ... })
+
+// CORRECT — middleware → inputValidator → client → server
+createMiddleware({ type: 'function' })
+  .middleware([dep])
+  .inputValidator(schema)
+  .client(({ next }) => next())
+  .server(({ next }) => next())
+```
+
+## Cross-References
+
+- [start-core/server-functions](../tanstack-start-core-server-functions/SKILL.md) — what middleware wraps
+- [start-core/server-routes](../tanstack-start-core-server-routes/SKILL.md) — middleware on API endpoints

--- a/.agents/skills/tanstack-start-core-middleware/SKILL.md
+++ b/.agents/skills/tanstack-start-core-middleware/SKILL.md
@@ -10,8 +10,8 @@ type: sub-skill
 library: tanstack-start
 library_version: '1.166.2'
 requires:
-  - start-core
-  - start-core/server-functions
+  - tanstack-start-core
+  - tanstack-start-core-server-functions
 sources:
   - TanStack/router:docs/start/framework/react/guide/middleware.md
 ---

--- a/.agents/skills/tanstack-start-core-server-functions/SKILL.md
+++ b/.agents/skills/tanstack-start-core-server-functions/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   handling, file organization (.functions.ts, .server.ts).
 type: sub-skill
 library: tanstack-start
-library_version: '1.166.2'
+library_version: '1.167.42'
 requires:
   - tanstack-start-core
 sources:
@@ -331,5 +331,5 @@ const deletePostFn = useServerFn(deletePost)
 
 ## Cross-References
 
-- [start-core/execution-model](../tanstack-start-core-execution-model/SKILL.md) — understanding where code runs
-- [start-core/middleware](../tanstack-start-core-middleware/SKILL.md) — composing server functions with middleware
+- [tanstack-start-core-execution-model](../tanstack-start-core-execution-model/SKILL.md) — understanding where code runs
+- [tanstack-start-core-middleware](../tanstack-start-core-middleware/SKILL.md) — composing server functions with middleware

--- a/.agents/skills/tanstack-start-core-server-functions/SKILL.md
+++ b/.agents/skills/tanstack-start-core-server-functions/SKILL.md
@@ -10,7 +10,7 @@ type: sub-skill
 library: tanstack-start
 library_version: '1.166.2'
 requires:
-  - start-core
+  - tanstack-start-core
 sources:
   - TanStack/router:docs/start/framework/react/guide/server-functions.md
 ---

--- a/.agents/skills/tanstack-start-core-server-functions/SKILL.md
+++ b/.agents/skills/tanstack-start-core-server-functions/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: tanstack-start-core-server-functions
+description: >-
+  createServerFn (GET/POST), inputValidator (Zod or function),
+  useServerFn hook, server context utilities (getRequest,
+  getRequestHeader, setResponseHeader, setResponseStatus), error
+  handling (throw errors, redirect, notFound), streaming, FormData
+  handling, file organization (.functions.ts, .server.ts).
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/server-functions.md
+---
+
+# Server Functions
+
+Server functions are type-safe RPCs created with `createServerFn`. They run exclusively on the server but can be called from anywhere — loaders, components, hooks, event handlers, or other server functions.
+
+> **CRITICAL**: Loaders are ISOMORPHIC — they run on BOTH client and server. Database queries, file system access, and secret API keys MUST go inside `createServerFn`, NOT in loaders directly.
+> **CRITICAL**: Do not use `"use server"` directives, `getServerSideProps`, or any Next.js/Remix server patterns. TanStack Start uses `createServerFn` exclusively.
+
+## Basic Usage
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+
+// GET (default)
+const getData = createServerFn().handler(async () => {
+  return { message: 'Hello from server!' }
+})
+
+// POST
+const saveData = createServerFn({ method: 'POST' }).handler(async () => {
+  return { success: true }
+})
+```
+
+## Calling from Loaders
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+
+const getPosts = createServerFn({ method: 'GET' }).handler(async () => {
+  const posts = await db.query('SELECT * FROM posts')
+  return { posts }
+})
+
+export const Route = createFileRoute('/posts')({
+  loader: () => getPosts(),
+  component: PostList,
+})
+
+function PostList() {
+  const { posts } = Route.useLoaderData()
+  return (
+    <ul>
+      {posts.map((p) => (
+        <li key={p.id}>{p.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Calling from Components
+
+Use the `useServerFn` hook to call server functions from event handlers:
+
+```tsx
+import { useServerFn } from '@tanstack/react-start'
+
+const deletePost = createServerFn({ method: 'POST' })
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    await db.delete('posts').where({ id: data.id })
+    return { success: true }
+  })
+
+function DeleteButton({ postId }: { postId: string }) {
+  const deletePostFn = useServerFn(deletePost)
+
+  return (
+    <button onClick={() => deletePostFn({ data: { id: postId } })}>
+      Delete
+    </button>
+  )
+}
+```
+
+## Input Validation
+
+### Basic Validator
+
+```tsx
+const greetUser = createServerFn({ method: 'GET' })
+  .inputValidator((data: { name: string }) => data)
+  .handler(async ({ data }) => {
+    return `Hello, ${data.name}!`
+  })
+
+await greetUser({ data: { name: 'John' } })
+```
+
+### Zod Validator
+
+```tsx
+import { z } from 'zod'
+
+const createUser = createServerFn({ method: 'POST' })
+  .inputValidator(
+    z.object({
+      name: z.string().min(1),
+      age: z.number().min(0),
+    }),
+  )
+  .handler(async ({ data }) => {
+    return `Created user: ${data.name}, age ${data.age}`
+  })
+```
+
+### FormData
+
+```tsx
+const submitForm = createServerFn({ method: 'POST' })
+  .inputValidator((data) => {
+    if (!(data instanceof FormData)) {
+      throw new Error('Expected FormData')
+    }
+    return {
+      name: data.get('name')?.toString() || '',
+      email: data.get('email')?.toString() || '',
+    }
+  })
+  .handler(async ({ data }) => {
+    return { success: true }
+  })
+```
+
+## Error Handling
+
+### Errors
+
+```tsx
+const riskyFunction = createServerFn().handler(async () => {
+  throw new Error('Something went wrong!')
+})
+
+try {
+  await riskyFunction()
+} catch (error) {
+  console.log(error.message) // "Something went wrong!"
+}
+```
+
+### Redirects
+
+```tsx
+import { redirect } from '@tanstack/react-router'
+
+const requireAuth = createServerFn().handler(async () => {
+  const user = await getCurrentUser()
+  if (!user) {
+    throw redirect({ to: '/login' })
+  }
+  return user
+})
+```
+
+### Not Found
+
+```tsx
+import { notFound } from '@tanstack/react-router'
+
+const getPost = createServerFn()
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    const post = await db.findPost(data.id)
+    if (!post) {
+      throw notFound()
+    }
+    return post
+  })
+```
+
+## Server Context Utilities
+
+Access request/response details inside server function handlers:
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+import {
+  getRequest,
+  getRequestHeader,
+  setResponseHeaders,
+  setResponseStatus,
+} from '@tanstack/react-start/server'
+
+const getCachedData = createServerFn({ method: 'GET' }).handler(async () => {
+  const request = getRequest()
+  const authHeader = getRequestHeader('Authorization')
+
+  setResponseHeaders({
+    'Cache-Control': 'public, max-age=300',
+  })
+  setResponseStatus(200)
+
+  return fetchData()
+})
+```
+
+Available utilities:
+
+- `getRequest()` — full Request object
+- `getRequestHeader(name)` — single request header
+- `setResponseHeader(name, value)` — single response header
+- `setResponseHeaders(headers)` — multiple response headers
+- `setResponseStatus(code)` — HTTP status code
+
+## File Organization
+
+```text
+src/utils/
+├── users.functions.ts   # createServerFn wrappers (safe to import anywhere)
+├── users.server.ts      # Server-only helpers (DB queries, internal logic)
+└── schemas.ts           # Shared validation schemas (client-safe)
+```
+
+```tsx
+// users.server.ts — server-only helpers
+import { db } from '~/db'
+
+export async function findUserById(id: string) {
+  return db.query.users.findFirst({ where: eq(users.id, id) })
+}
+```
+
+```tsx
+// users.functions.ts — server functions
+import { createServerFn } from '@tanstack/react-start'
+import { findUserById } from './users.server'
+
+export const getUser = createServerFn({ method: 'GET' })
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    return findUserById(data.id)
+  })
+```
+
+Static imports of server functions are safe — the build replaces implementations with RPC stubs in client bundles.
+
+## Common Mistakes
+
+### 1. CRITICAL: Putting server-only code in loaders
+
+```tsx
+// WRONG — loader is ISOMORPHIC, runs on BOTH client and server
+export const Route = createFileRoute('/posts')({
+  loader: async () => {
+    const posts = await db.query('SELECT * FROM posts')
+    return { posts }
+  },
+})
+
+// CORRECT — use createServerFn for server-only logic
+const getPosts = createServerFn({ method: 'GET' }).handler(async () => {
+  const posts = await db.query('SELECT * FROM posts')
+  return { posts }
+})
+
+export const Route = createFileRoute('/posts')({
+  loader: () => getPosts(),
+})
+```
+
+### 2. CRITICAL: Using Next.js/Remix server patterns
+
+```tsx
+// WRONG — "use server" is a React directive, not used in TanStack Start
+'use server'
+export async function getUser() { ... }
+
+// WRONG — getServerSideProps is Next.js
+export async function getServerSideProps() { ... }
+
+// CORRECT — TanStack Start uses createServerFn
+const getUser = createServerFn({ method: 'GET' })
+  .handler(async () => { ... })
+```
+
+### 3. HIGH: Dynamic imports for server functions
+
+```tsx
+// WRONG — can cause bundler issues
+const { getUser } = await import('~/utils/users.functions')
+
+// CORRECT — static imports are safe, build handles environment shaking
+import { getUser } from '~/utils/users.functions'
+```
+
+### 4. HIGH: Awaiting server function without calling it
+
+`createServerFn` returns a function — it must be invoked with `()`:
+
+```tsx
+// WRONG — getItems is a function, not a Promise
+const data = await getItems
+
+// CORRECT — call the function
+const data = await getItems()
+
+// With validated input
+const data = await getItems({ data: { id: '1' } })
+```
+
+### 5. MEDIUM: Not using useServerFn for component calls
+
+When calling server functions from event handlers in components, use `useServerFn` to get proper React integration:
+
+```tsx
+// WRONG — direct call doesn't integrate with React lifecycle
+<button onClick={() => deletePost({ data: { id } })}>Delete</button>
+
+// CORRECT — useServerFn integrates with React
+const deletePostFn = useServerFn(deletePost)
+<button onClick={() => deletePostFn({ data: { id } })}>Delete</button>
+```
+
+## Cross-References
+
+- [start-core/execution-model](../tanstack-start-core-execution-model/SKILL.md) — understanding where code runs
+- [start-core/middleware](../tanstack-start-core-middleware/SKILL.md) — composing server functions with middleware

--- a/.agents/skills/tanstack-start-core-server-routes/SKILL.md
+++ b/.agents/skills/tanstack-start-core-server-routes/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: tanstack-start-core-server-routes
+description: >-
+  Server-side API endpoints using the server property on
+  createFileRoute, HTTP method handlers (GET, POST, PUT, DELETE),
+  createHandlers for per-handler middleware, handler context
+  (request, params, context), request body parsing, response
+  helpers, file naming for API routes.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/server-routes.md
+---
+
+# Server Routes
+
+Server routes are API endpoints defined alongside app routes in the `src/routes` directory. They use the `server` property on `createFileRoute` and handle raw HTTP requests.
+
+## Basic Server Route
+
+```ts
+// src/routes/api/hello.ts
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/hello')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        return new Response('Hello, World!')
+      },
+    },
+  },
+})
+```
+
+## Combining Server Route and App Route
+
+The same file can define both a server route and a UI route:
+
+```tsx
+// src/routes/hello.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+
+export const Route = createFileRoute('/hello')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body = await request.json()
+        return Response.json({ message: `Hello, ${body.name}!` })
+      },
+    },
+  },
+  component: HelloComponent,
+})
+
+function HelloComponent() {
+  const [reply, setReply] = useState('')
+  return (
+    <button
+      onClick={() => {
+        fetch('/hello', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Tanner' }),
+        })
+          .then((res) => res.json())
+          .then((data) => setReply(data.message))
+      }}
+    >
+      Say Hello {reply && `- ${reply}`}
+    </button>
+  )
+}
+```
+
+## File Route Conventions
+
+Server routes follow TanStack Router file-based routing conventions:
+
+| File                        | Route                         |
+| --------------------------- | ----------------------------- |
+| `routes/users.ts`           | `/users`                      |
+| `routes/users/$id.ts`       | `/users/$id`                  |
+| `routes/users/$id/posts.ts` | `/users/$id/posts`            |
+| `routes/api/file/$.ts`      | `/api/file/$` (splat)         |
+| `routes/my-script[.]js.ts`  | `/my-script.js` (escaped dot) |
+
+## Unique Route Paths
+
+Each route can only have a single handler file. These would conflict:
+
+- `routes/users.ts`
+- `routes/users.index.ts`
+- `routes/users/index.ts`
+
+## Handler Context
+
+Each handler receives:
+
+- `request` — the incoming [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object
+- `params` — dynamic path parameters
+- `context` — context from middleware
+- `pathname` — the matched pathname
+- `next` — call to fall through to SSR (returns a `Response`)
+
+## Dynamic Path Params
+
+```ts
+// routes/users/$id.ts
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/users/$id')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        return new Response(`User ID: ${params.id}`)
+      },
+    },
+  },
+})
+```
+
+## Splat/Wildcard Params
+
+```ts
+// routes/file/$.ts
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/file/$')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        return new Response(`File: ${params._splat}`)
+      },
+    },
+  },
+})
+```
+
+## Request Body Handling
+
+```ts
+export const Route = createFileRoute('/api/users')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body = await request.json()
+        return Response.json({ created: body.name })
+      },
+    },
+  },
+})
+```
+
+Other body methods: `request.text()`, `request.formData()`.
+
+## JSON Responses
+
+```ts
+// Using Response.json helper
+handlers: {
+  GET: async () => {
+    return Response.json({ message: 'Hello!' })
+  },
+}
+```
+
+## Status Codes and Headers
+
+```ts
+handlers: {
+  GET: async ({ params }) => {
+    const user = await findUser(params.id)
+    if (!user) {
+      return new Response('Not found', { status: 404 })
+    }
+    return Response.json(user)
+  },
+}
+```
+
+```ts
+handlers: {
+  GET: async () => {
+    return new Response('Hello', {
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  },
+}
+```
+
+## Middleware on Server Routes
+
+### All handlers
+
+```tsx
+export const Route = createFileRoute('/api/admin')({
+  server: {
+    middleware: [authMiddleware, loggerMiddleware],
+    handlers: {
+      GET: async ({ context }) => Response.json(context.user),
+      POST: async ({ request, context }) => {
+        /* ... */
+      },
+    },
+  },
+})
+```
+
+### Specific handlers with createHandlers
+
+```tsx
+export const Route = createFileRoute('/api/data')({
+  server: {
+    handlers: ({ createHandlers }) =>
+      createHandlers({
+        GET: async () => Response.json({ public: true }),
+        POST: {
+          middleware: [authMiddleware],
+          handler: async ({ context }) => {
+            return Response.json({ user: context.session.user })
+          },
+        },
+      }),
+  },
+})
+```
+
+### Combined route-level and handler-specific
+
+```tsx
+export const Route = createFileRoute('/api/posts')({
+  server: {
+    middleware: [authMiddleware], // runs first for all
+    handlers: ({ createHandlers }) =>
+      createHandlers({
+        GET: async () => Response.json([]),
+        POST: {
+          middleware: [validationMiddleware], // runs after auth, POST only
+          handler: async ({ request }) => {
+            const body = await request.json()
+            return Response.json({ created: true })
+          },
+        },
+      }),
+  },
+})
+```
+
+## Common Mistakes
+
+### 1. MEDIUM: Duplicate route paths
+
+```text
+# WRONG — both resolve to /users, causes error
+routes/users.ts
+routes/users/index.ts
+
+# CORRECT — pick one
+routes/users.ts
+```
+
+### 2. MEDIUM: Forgetting to await request body methods
+
+```ts
+// WRONG — body is a Promise, not the actual data
+const body = request.json()
+
+// CORRECT — await the promise
+const body = await request.json()
+```
+
+## Cross-References
+
+- [start-core/middleware](../tanstack-start-core-middleware/SKILL.md) — middleware for server routes
+- [start-core/server-functions](../tanstack-start-core-server-functions/SKILL.md) — alternative for RPC-style calls

--- a/.agents/skills/tanstack-start-core-server-routes/SKILL.md
+++ b/.agents/skills/tanstack-start-core-server-routes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   helpers, file naming for API routes.
 type: sub-skill
 library: tanstack-start
-library_version: '1.166.2'
+library_version: '1.167.42'
 requires:
   - tanstack-start-core
 sources:
@@ -276,5 +276,5 @@ const body = await request.json()
 
 ## Cross-References
 
-- [start-core/middleware](../tanstack-start-core-middleware/SKILL.md) — middleware for server routes
-- [start-core/server-functions](../tanstack-start-core-server-functions/SKILL.md) — alternative for RPC-style calls
+- [tanstack-start-core-middleware](../tanstack-start-core-middleware/SKILL.md) — middleware for server routes
+- [tanstack-start-core-server-functions](../tanstack-start-core-server-functions/SKILL.md) — alternative for RPC-style calls

--- a/.agents/skills/tanstack-start-core-server-routes/SKILL.md
+++ b/.agents/skills/tanstack-start-core-server-routes/SKILL.md
@@ -10,7 +10,7 @@ type: sub-skill
 library: tanstack-start
 library_version: '1.166.2'
 requires:
-  - start-core
+  - tanstack-start-core
 sources:
   - TanStack/router:docs/start/framework/react/guide/server-routes.md
 ---

--- a/.agents/skills/tanstack-start-core/SKILL.md
+++ b/.agents/skills/tanstack-start-core/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   tsconfig configuration. Entry point for all Start skills.
 type: core
 library: tanstack-start
-library_version: '1.166.2'
+library_version: '1.167.42'
 sources:
   - TanStack/router:docs/start/framework/react/build-from-scratch.md
   - TanStack/router:docs/start/framework/react/quick-start.md
@@ -26,29 +26,29 @@ TanStack Start is a full-stack React framework built on TanStack Router and Vite
 
 | Task                                         | Sub-Skill                                                           |
 | -------------------------------------------- | ------------------------------------------------------------------- |
-| Type-safe RPCs, data fetching, mutations     | [start-core/server-functions/SKILL.md](../tanstack-start-core-server-functions/SKILL.md) |
-| Request/function middleware, context, auth   | [start-core/middleware/SKILL.md](../tanstack-start-core-middleware/SKILL.md)             |
-| Isomorphic execution, environment boundaries | [start-core/execution-model/SKILL.md](../tanstack-start-core-execution-model/SKILL.md)   |
-| REST API endpoints alongside app routes      | [start-core/server-routes/SKILL.md](../tanstack-start-core-server-routes/SKILL.md)       |
-| Hosting, SSR modes, prerendering, SEO        | [start-core/deployment/SKILL.md](../tanstack-start-core-deployment/SKILL.md)             |
+| Type-safe RPCs, data fetching, mutations     | [tanstack-start-core-server-functions/SKILL.md](../tanstack-start-core-server-functions/SKILL.md) |
+| Request/function middleware, context, auth   | [tanstack-start-core-middleware/SKILL.md](../tanstack-start-core-middleware/SKILL.md)             |
+| Isomorphic execution, environment boundaries | [tanstack-start-core-execution-model/SKILL.md](../tanstack-start-core-execution-model/SKILL.md)   |
+| REST API endpoints alongside app routes      | [tanstack-start-core-server-routes/SKILL.md](../tanstack-start-core-server-routes/SKILL.md)       |
+| Hosting, SSR modes, prerendering, SEO        | [tanstack-start-core-deployment/SKILL.md](../tanstack-start-core-deployment/SKILL.md)             |
 
 ## Quick Decision Tree
 
 ```text
 Need to run code exclusively on the server (DB, secrets)?
-  → start-core/server-functions
+  → tanstack-start-core-server-functions
 
 Need auth checks, logging, or shared logic across server functions?
-  → start-core/middleware
+  → tanstack-start-core-middleware
 
 Need to understand where code runs (server vs client)?
-  → start-core/execution-model
+  → tanstack-start-core-execution-model
 
 Need a REST API endpoint (GET/POST/PUT/DELETE)?
-  → start-core/server-routes
+  → tanstack-start-core-server-routes
 
 Need to deploy, configure SSR, or prerender?
-  → start-core/deployment
+  → tanstack-start-core-deployment
 ```
 
 ## Project Setup
@@ -207,4 +207,4 @@ function RootComponent() {
 
 ## Version Note
 
-This skill targets `@tanstack/react-start` v1.166.2 and `@tanstack/start-client-core` v1.166.2.
+This skill targets the repo lockfile versions: `@tanstack/react-start` v1.167.42 and `@tanstack/start-client-core` v1.167.17.

--- a/.agents/skills/tanstack-start-core/SKILL.md
+++ b/.agents/skills/tanstack-start-core/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: tanstack-start-core
+description: >-
+  Core overview for TanStack Start: tanstackStart() Vite plugin,
+  getRouter() factory, root route document shell (HeadContent,
+  Scripts, Outlet), client/server entry points, routeTree.gen.ts,
+  tsconfig configuration. Entry point for all Start skills.
+type: core
+library: tanstack-start
+library_version: '1.166.2'
+sources:
+  - TanStack/router:docs/start/framework/react/build-from-scratch.md
+  - TanStack/router:docs/start/framework/react/quick-start.md
+  - TanStack/router:docs/start/framework/react/guide/routing.md
+---
+
+# TanStack Start Core
+
+TanStack Start is a full-stack React framework built on TanStack Router and Vite. It adds SSR, streaming, server functions (type-safe RPCs), middleware, server routes, and universal deployment.
+
+> **CRITICAL**: All code in TanStack Start is ISOMORPHIC by default — it runs in BOTH server and client environments. Loaders run on both server AND client. To run code exclusively on the server, use `createServerFn`. This is the #1 AI agent mistake.
+> **CRITICAL**: TanStack Start is NOT Next.js. Do not generate `getServerSideProps`, `"use server"` directives, `app/layout.tsx`, or any Next.js/Remix patterns. Use `createServerFn` for server-only code.
+> **CRITICAL**: Types are FULLY INFERRED. Never cast, never annotate inferred values.
+
+## Sub-Skills
+
+| Task                                         | Sub-Skill                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------- |
+| Type-safe RPCs, data fetching, mutations     | [start-core/server-functions/SKILL.md](../tanstack-start-core-server-functions/SKILL.md) |
+| Request/function middleware, context, auth   | [start-core/middleware/SKILL.md](../tanstack-start-core-middleware/SKILL.md)             |
+| Isomorphic execution, environment boundaries | [start-core/execution-model/SKILL.md](../tanstack-start-core-execution-model/SKILL.md)   |
+| REST API endpoints alongside app routes      | [start-core/server-routes/SKILL.md](../tanstack-start-core-server-routes/SKILL.md)       |
+| Hosting, SSR modes, prerendering, SEO        | [start-core/deployment/SKILL.md](../tanstack-start-core-deployment/SKILL.md)             |
+
+## Quick Decision Tree
+
+```text
+Need to run code exclusively on the server (DB, secrets)?
+  → start-core/server-functions
+
+Need auth checks, logging, or shared logic across server functions?
+  → start-core/middleware
+
+Need to understand where code runs (server vs client)?
+  → start-core/execution-model
+
+Need a REST API endpoint (GET/POST/PUT/DELETE)?
+  → start-core/server-routes
+
+Need to deploy, configure SSR, or prerender?
+  → start-core/deployment
+```
+
+## Project Setup
+
+### 1. Install Dependencies
+
+```bash
+npm i @tanstack/react-start @tanstack/react-router react react-dom
+npm i -D vite @vitejs/plugin-react typescript
+```
+
+### 2. Configure Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    // MUST come before react()
+    tanstackStart(),
+    viteReact(),
+  ],
+})
+```
+
+### 3. Create Router Factory
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export function getRouter() {
+  const router = createRouter({
+    routeTree,
+    scrollRestoration: true,
+  })
+
+  return router
+}
+```
+
+### 4. Create Root Route with Document Shell
+
+```tsx
+// src/routes/__root.tsx
+import type { ReactNode } from 'react'
+import {
+  Outlet,
+  createRootRoute,
+  HeadContent,
+  Scripts,
+} from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [
+      { charSet: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { title: 'My App' },
+    ],
+  }),
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### 5. Create Index Route with Server Function
+
+```tsx
+// src/routes/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+
+const getGreeting = createServerFn({ method: 'GET' }).handler(async () => {
+  return { message: 'Hello from the server!' }
+})
+
+export const Route = createFileRoute('/')({
+  loader: () => getGreeting(),
+  component: HomePage,
+})
+
+function HomePage() {
+  const data = Route.useLoaderData()
+  return <h1>{data.message}</h1>
+}
+```
+
+## Common Mistakes
+
+### 1. CRITICAL: React plugin before Start plugin in Vite config
+
+```ts
+// WRONG — route generation and server function compilation fail
+plugins: [react(), tanstackStart()]
+
+// CORRECT — Start plugin must come first
+plugins: [tanstackStart(), react()]
+```
+
+### 2. HIGH: Enabling verbatimModuleSyntax in tsconfig
+
+`verbatimModuleSyntax` causes server bundles to leak into client bundles. Keep it disabled.
+
+### 3. HIGH: Missing Scripts component in root route
+
+The `<Scripts />` component must be rendered in the `<body>` of the root route. Without it, client-side JavaScript does not load and hydration fails.
+
+```tsx
+// WRONG — no Scripts
+function RootComponent() {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+      </body>
+    </html>
+  )
+}
+
+// CORRECT — Scripts in body
+function RootComponent() {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+## Version Note
+
+This skill targets `@tanstack/react-start` v1.166.2 and `@tanstack/start-client-core` v1.166.2.

--- a/.agents/skills/tanstack-start-core/SKILL.md
+++ b/.agents/skills/tanstack-start-core/SKILL.md
@@ -56,8 +56,8 @@ Need to deploy, configure SSR, or prerender?
 ### 1. Install Dependencies
 
 ```bash
-npm i @tanstack/react-start @tanstack/react-router react react-dom
-npm i -D vite @vitejs/plugin-react typescript
+pnpm add @tanstack/react-start @tanstack/react-router react react-dom
+pnpm add -D vite @vitejs/plugin-react typescript
 ```
 
 ### 2. Configure Vite

--- a/.agents/skills/tanstack-start-core/SKILL.md
+++ b/.agents/skills/tanstack-start-core/SKILL.md
@@ -162,8 +162,14 @@ function HomePage() {
 // WRONG — route generation and server function compilation fail
 plugins: [react(), tanstackStart()]
 
-// CORRECT — Start plugin must come first
+// CORRECT — Start plugin must come before React
 plugins: [tanstackStart(), react()]
+```
+
+If `@tanstack/devtools-vite` is installed, keep `devtools()` first and place `tanstackStart()` before `viteReact()`:
+
+```ts
+plugins: [devtools(), tanstackStart(), viteReact()]
 ```
 
 ### 2. HIGH: Enabling verbatimModuleSyntax in tsconfig

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Agent Skills Setup
 
-This repository uses project-local Agent Skills installed by TanStack Intent.
+This repository uses project-local Agent Skills sourced from TanStack Intent and shipped TanStack package skills.
 
 Exact CLI commands run:
 
@@ -15,6 +15,8 @@ Agent rule for architectural or library-specific work:
 - Load the matching skill by name first, then implement.
 - TanStack Router skills are named `tanstack-router-core*`.
 - TanStack Start skills are named `tanstack-start-core*`.
+- TanStack DB skills are named `db-core*` and `meta-framework`.
+- TanStack Devtools Vite skill is named `devtools-vite-plugin`.
 - Do not maintain filesystem links to generated or installed skill files in this guide.
 
 <!-- intent-skills:start -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Agent Skills Setup
 
-This repository has project-local Agent Skills in `.agents/skills`.
+This repository uses project-local Agent Skills installed by TanStack Intent.
 
 Exact CLI commands run:
 
@@ -12,14 +12,14 @@ Exact CLI commands run:
 Agent rule for architectural or library-specific work:
 
 - Do not guess patterns that are covered by shipped TanStack skills.
-- Load the matching project-local skill from `.agents/skills` first, then implement.
+- Load the matching skill by name first, then implement.
 - TanStack Router skills are named `tanstack-router-core*`.
 - TanStack Start skills are named `tanstack-start-core*`.
+- Do not maintain filesystem links to generated or installed skill files in this guide.
 
 <!-- intent-skills:start -->
-# TanStack Router and TanStack Start skills are installed as project-local
-# Agent Skills under `.agents/skills`; do not duplicate their node_modules
-# skill paths here.
+# Skill mappings are intentionally omitted. Use Agent Skills by name via
+# discovery; do not add node_modules or local filesystem skill paths here.
 <!-- intent-skills:end -->
 
 ## Durable Project Context
@@ -74,4 +74,4 @@ Next steps:
 
 - Decide whether `apps/web/src/tanstack-db/index.ts` replaces the removed `db-collections` module and update imports accordingly.
 - Add a small developer note or script for regenerating `routeTree.gen.ts` after route refactors.
-- If additional TanStack areas are adopted, install or update project-local Agent Skills under `.agents/skills` and reference them by skill name.
+- If additional TanStack areas are adopted, install or update project-local Agent Skills and reference them by skill name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,7 @@ Agent rule for architectural or library-specific work:
 - TanStack Devtools Vite skill is named `devtools-vite-plugin`.
 - Do not maintain filesystem links to generated or installed skill files in this guide.
 
-<!-- intent-skills:start -->
-# Skill mappings are intentionally omitted. Use Agent Skills by name via
-# discovery; do not add node_modules or local filesystem skill paths here.
-<!-- intent-skills:end -->
+Skill mappings are intentionally omitted. Use Agent Skills by name via discovery; do not add node_modules or local filesystem skill paths here.
 
 ## Durable Project Context
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Guide
 
-## Intent Setup
+## Agent Skills Setup
 
-This repository is wired for TanStack Intent skill mappings.
+This repository has project-local Agent Skills in `.agents/skills`.
 
 Exact CLI commands run:
 
@@ -12,21 +12,14 @@ Exact CLI commands run:
 Agent rule for architectural or library-specific work:
 
 - Do not guess patterns that are covered by shipped TanStack skills.
-- Load the matching skill file first, then implement.
+- Load the matching project-local skill from `.agents/skills` first, then implement.
+- TanStack Router skills are named `tanstack-router-core*`.
+- TanStack Start skills are named `tanstack-start-core*`.
 
 <!-- intent-skills:start -->
-# Skill mappings - when working in these areas, load the linked skill file into context.
-skills:
-  - task: "making architectural or library-specific changes in TanStack Start app structure and runtime boundaries"
-    load: "apps/web/node_modules/@tanstack/start-client-core/skills/start-core/SKILL.md"
-  - task: "editing API endpoints in file routes with createFileRoute server handlers"
-    load: "apps/web/node_modules/@tanstack/start-client-core/skills/start-core/server-routes/SKILL.md"
-  - task: "changing TanStack Router route structure, createFileRoute paths, navigation, and URL behavior"
-    load: "apps/web/node_modules/@tanstack/router-core/skills/router-core/SKILL.md"
-  - task: "working on TanStack DB collections, preload patterns, and React live-query usage"
-    load: "apps/web/node_modules/@tanstack/db/skills/meta-framework/SKILL.md"
-  - task: "changing devtools wiring or Vite devtools plugin behavior/order"
-    load: "apps/web/node_modules/@tanstack/devtools-vite/skills/devtools-vite-plugin/SKILL.md"
+# TanStack Router and TanStack Start skills are installed as project-local
+# Agent Skills under `.agents/skills`; do not duplicate their node_modules
+# skill paths here.
 <!-- intent-skills:end -->
 
 ## Durable Project Context
@@ -81,4 +74,4 @@ Next steps:
 
 - Decide whether `apps/web/src/tanstack-db/index.ts` replaces the removed `db-collections` module and update imports accordingly.
 - Add a small developer note or script for regenerating `routeTree.gen.ts` after route refactors.
-- If additional TanStack areas are adopted (AI tooling, server functions middleware, deployment targets), extend the `intent-skills` block with the exact shipped skill path.
+- If additional TanStack areas are adopted, install or update project-local Agent Skills under `.agents/skills` and reference them by skill name.


### PR DESCRIPTION
## Summary
- add project-local Agent Skills for TanStack Router core and TanStack Start core guidance
- include the TanStack Router search params validation reference
- update AGENTS.md to point agents at local skills instead of redundant node_modules skill paths

## Validation
- verified skill directory names match SKILL.md frontmatter names
- verified relative links in installed skills resolve